### PR TITLE
feat: update to beta2 schema

### DIFF
--- a/libs/shared/package.json
+++ b/libs/shared/package.json
@@ -6,8 +6,10 @@
   },
   "scripts": {
     "migrate:dev": "dotenv -e .env.dev prisma migrate dev",
+    "migrate:test": "dotenv -e .env.test prisma migrate dev",
     "migrate:deploy": "dotenv -e .env.prod prisma migrate deploy",
     "seed:dev": "dotenv -e .env.dev ts-node ./src/prisma/seed.ts",
+    "seed:test": "dotenv -e .env.test ts-node ./src/prisma/seed.ts",
     "seed:prod": "dotenv -e .env.prod ts-node ./src/prisma/seed.ts",
     "prisma:generate": "prisma generate"
   },

--- a/libs/shared/src/prisma/migrations/20230824195957_beta2/migration.sql
+++ b/libs/shared/src/prisma/migrations/20230824195957_beta2/migration.sql
@@ -1,0 +1,540 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `deleted` on the `Guild` table. All the data in the column will be lost.
+  - You are about to drop the column `updateedAt` on the `Guild` table. All the data in the column will be lost.
+  - You are about to drop the column `categoryId` on the `Post` table. All the data in the column will be lost.
+  - You are about to drop the column `closed` on the `Post` table. All the data in the column will be lost.
+  - You are about to drop the column `deleted` on the `Post` table. All the data in the column will be lost.
+  - You are about to drop the column `messageId` on the `Post` table. All the data in the column will be lost.
+  - You are about to drop the column `nego` on the `Post` table. All the data in the column will be lost.
+  - You are about to drop the column `price` on the `Post` table. All the data in the column will be lost.
+  - You are about to drop the column `published` on the `Post` table. All the data in the column will be lost.
+  - You are about to drop the column `subTitle` on the `Post` table. All the data in the column will be lost.
+  - You are about to drop the column `type` on the `Post` table. All the data in the column will be lost.
+  - You are about to drop the column `updateedAt` on the `Post` table. All the data in the column will be lost.
+  - You are about to drop the column `userId` on the `Post` table. All the data in the column will be lost.
+  - You are about to drop the column `deleted` on the `Role` table. All the data in the column will be lost.
+  - You are about to drop the column `deleted` on the `Session` table. All the data in the column will be lost.
+  - You are about to drop the column `deleted` on the `SocialAccount` table. All the data in the column will be lost.
+  - You are about to drop the column `deleted` on the `User` table. All the data in the column will be lost.
+  - You are about to drop the column `deleted` on the `VerificationToken` table. All the data in the column will be lost.
+  - You are about to drop the `Category` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `Image` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `Keyword` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `Tag` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `_KeywordToUser` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `_PostToTag` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `_RoleToUser` table. If the table is not empty, all the data it contains will be lost.
+  - Added the required column `updatedAt` to the `Guild` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `authorId` to the `Post` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `communityId` to the `Post` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `postCategoryId` to the `Post` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `updatedAt` to the `Post` table without a default value. This is not possible if the table is not empty.
+  - Made the column `content` on table `Post` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Category" DROP CONSTRAINT "Category_guildId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Image" DROP CONSTRAINT "Image_postId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Image" DROP CONSTRAINT "Image_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Post" DROP CONSTRAINT "Post_categoryId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Post" DROP CONSTRAINT "Post_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_KeywordToUser" DROP CONSTRAINT "_KeywordToUser_A_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_KeywordToUser" DROP CONSTRAINT "_KeywordToUser_B_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_PostToTag" DROP CONSTRAINT "_PostToTag_A_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_PostToTag" DROP CONSTRAINT "_PostToTag_B_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_RoleToUser" DROP CONSTRAINT "_RoleToUser_A_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_RoleToUser" DROP CONSTRAINT "_RoleToUser_B_fkey";
+
+-- DropIndex
+DROP INDEX "Post_messageId_key";
+
+-- AlterTable
+ALTER TABLE "Guild" DROP COLUMN "deleted",
+DROP COLUMN "updateedAt",
+ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "description" TEXT,
+ADD COLUMN     "icon" TEXT,
+ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Post" DROP COLUMN "categoryId",
+DROP COLUMN "closed",
+DROP COLUMN "deleted",
+DROP COLUMN "messageId",
+DROP COLUMN "nego",
+DROP COLUMN "price",
+DROP COLUMN "published",
+DROP COLUMN "subTitle",
+DROP COLUMN "type",
+DROP COLUMN "updateedAt",
+DROP COLUMN "userId",
+ADD COLUMN     "authorId" TEXT NOT NULL,
+ADD COLUMN     "communityId" TEXT NOT NULL,
+ADD COLUMN     "deletedAt" TIMESTAMP(3),
+ADD COLUMN     "images" JSONB[],
+ADD COLUMN     "postCategoryId" TEXT NOT NULL,
+ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL,
+ALTER COLUMN "content" SET NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Role" DROP COLUMN "deleted",
+ADD COLUMN     "deletedAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "Session" DROP COLUMN "deleted",
+ADD COLUMN     "deletedAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "SocialAccount" DROP COLUMN "deleted",
+ADD COLUMN     "deletedAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "deleted",
+ADD COLUMN     "deletedAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "VerificationToken" DROP COLUMN "deleted",
+ADD COLUMN     "deletedAt" TIMESTAMP(3);
+
+-- DropTable
+DROP TABLE "Category";
+
+-- DropTable
+DROP TABLE "Image";
+
+-- DropTable
+DROP TABLE "Keyword";
+
+-- DropTable
+DROP TABLE "Tag";
+
+-- DropTable
+DROP TABLE "_KeywordToUser";
+
+-- DropTable
+DROP TABLE "_PostToTag";
+
+-- DropTable
+DROP TABLE "_RoleToUser";
+
+-- CreateTable
+CREATE TABLE "Member" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+    "userId" TEXT NOT NULL,
+    "guildId" TEXT NOT NULL,
+
+    CONSTRAINT "Member_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Market" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "guildId" TEXT NOT NULL,
+
+    CONSTRAINT "Market_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Community" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "guildId" TEXT NOT NULL,
+
+    CONSTRAINT "Community_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PostCategory" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "rank" INTEGER,
+    "communityId" TEXT NOT NULL,
+
+    CONSTRAINT "PostCategory_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ProductCategory" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "rank" INTEGER,
+    "marketId" TEXT NOT NULL,
+
+    CONSTRAINT "ProductCategory_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Brand" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "logo" TEXT,
+    "rank" INTEGER,
+
+    CONSTRAINT "Brand_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PostComment" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+    "authorId" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "postId" TEXT NOT NULL,
+    "parentId" TEXT,
+
+    CONSTRAINT "PostComment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Offer" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+    "product" JSONB NOT NULL,
+    "price" INTEGER NOT NULL,
+    "priceCurrency" TEXT NOT NULL,
+    "businessFunction" TEXT NOT NULL,
+    "marketId" TEXT NOT NULL,
+    "brandId" TEXT,
+    "productCategoryId" TEXT NOT NULL,
+    "sellerId" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+
+    CONSTRAINT "Offer_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Demand" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+    "product" JSONB NOT NULL,
+    "price" INTEGER NOT NULL,
+    "priceCurrency" TEXT NOT NULL,
+    "businessFunction" TEXT NOT NULL,
+    "marketId" TEXT NOT NULL,
+    "brandId" TEXT,
+    "productCategoryId" TEXT NOT NULL,
+    "buyerId" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+
+    CONSTRAINT "Demand_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Swap" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+    "marketId" TEXT NOT NULL,
+    "price" INTEGER NOT NULL,
+    "priceCurrency" TEXT NOT NULL,
+    "product0" JSONB NOT NULL,
+    "product1" JSONB NOT NULL,
+    "brand0Id" TEXT,
+    "brand1Id" TEXT,
+    "productCategory0Id" TEXT NOT NULL,
+    "productCategory1Id" TEXT NOT NULL,
+    "proposerId" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+
+    CONSTRAINT "Swap_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Auction" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+    "endedAt" TIMESTAMP(3) NOT NULL,
+    "product" JSONB NOT NULL,
+    "marketId" TEXT NOT NULL,
+    "brandId" TEXT,
+    "productCategoryId" TEXT NOT NULL,
+    "sellerId" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+
+    CONSTRAINT "Auction_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AuctionComment" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+    "authorId" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "auctionId" TEXT NOT NULL,
+    "parentId" TEXT,
+
+    CONSTRAINT "AuctionComment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Bid" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "deletedAt" TIMESTAMP(3),
+    "canceledAt" TIMESTAMP(3),
+    "price" INTEGER NOT NULL,
+    "priceCurrency" TEXT NOT NULL,
+    "auctionId" TEXT NOT NULL,
+    "bidderId" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+
+    CONSTRAINT "Bid_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "DiscordChannelLink" (
+    "discordChannelId" TEXT NOT NULL,
+    "discordGuildId" TEXT NOT NULL,
+    "modelId" TEXT NOT NULL,
+    "modelName" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "DiscordMessageLink" (
+    "discordMessageId" TEXT NOT NULL,
+    "discordChannelId" TEXT NOT NULL,
+    "discordGuildId" TEXT NOT NULL,
+    "modelId" TEXT NOT NULL,
+    "modelName" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "DiscordMarketChannelLink" (
+    "productCategoryId" TEXT NOT NULL,
+    "discordOfferChannelId" TEXT NOT NULL,
+    "discordDemandChannelId" TEXT NOT NULL,
+    "discordSwapChannelId" TEXT NOT NULL,
+    "discordGuildId" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_MemberToRole" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_GuildToRole" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "_BrandToGuild" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Market_guildId_key" ON "Market"("guildId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Community_guildId_key" ON "Community"("guildId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DiscordChannelLink_discordChannelId_key" ON "DiscordChannelLink"("discordChannelId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DiscordMessageLink_discordMessageId_key" ON "DiscordMessageLink"("discordMessageId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DiscordMarketChannelLink_productCategoryId_key" ON "DiscordMarketChannelLink"("productCategoryId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_MemberToRole_AB_unique" ON "_MemberToRole"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_MemberToRole_B_index" ON "_MemberToRole"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_GuildToRole_AB_unique" ON "_GuildToRole"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_GuildToRole_B_index" ON "_GuildToRole"("B");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_BrandToGuild_AB_unique" ON "_BrandToGuild"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_BrandToGuild_B_index" ON "_BrandToGuild"("B");
+
+-- AddForeignKey
+ALTER TABLE "Member" ADD CONSTRAINT "Member_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Member" ADD CONSTRAINT "Member_guildId_fkey" FOREIGN KEY ("guildId") REFERENCES "Guild"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Market" ADD CONSTRAINT "Market_guildId_fkey" FOREIGN KEY ("guildId") REFERENCES "Guild"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Community" ADD CONSTRAINT "Community_guildId_fkey" FOREIGN KEY ("guildId") REFERENCES "Guild"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PostCategory" ADD CONSTRAINT "PostCategory_communityId_fkey" FOREIGN KEY ("communityId") REFERENCES "Community"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProductCategory" ADD CONSTRAINT "ProductCategory_marketId_fkey" FOREIGN KEY ("marketId") REFERENCES "Market"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Post" ADD CONSTRAINT "Post_communityId_fkey" FOREIGN KEY ("communityId") REFERENCES "Community"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Post" ADD CONSTRAINT "Post_postCategoryId_fkey" FOREIGN KEY ("postCategoryId") REFERENCES "PostCategory"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Post" ADD CONSTRAINT "Post_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PostComment" ADD CONSTRAINT "PostComment_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PostComment" ADD CONSTRAINT "PostComment_postId_fkey" FOREIGN KEY ("postId") REFERENCES "Post"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PostComment" ADD CONSTRAINT "PostComment_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "PostComment"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Offer" ADD CONSTRAINT "Offer_marketId_fkey" FOREIGN KEY ("marketId") REFERENCES "Market"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Offer" ADD CONSTRAINT "Offer_brandId_fkey" FOREIGN KEY ("brandId") REFERENCES "Brand"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Offer" ADD CONSTRAINT "Offer_productCategoryId_fkey" FOREIGN KEY ("productCategoryId") REFERENCES "ProductCategory"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Offer" ADD CONSTRAINT "Offer_sellerId_fkey" FOREIGN KEY ("sellerId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Demand" ADD CONSTRAINT "Demand_marketId_fkey" FOREIGN KEY ("marketId") REFERENCES "Market"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Demand" ADD CONSTRAINT "Demand_brandId_fkey" FOREIGN KEY ("brandId") REFERENCES "Brand"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Demand" ADD CONSTRAINT "Demand_productCategoryId_fkey" FOREIGN KEY ("productCategoryId") REFERENCES "ProductCategory"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Demand" ADD CONSTRAINT "Demand_buyerId_fkey" FOREIGN KEY ("buyerId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Swap" ADD CONSTRAINT "Swap_marketId_fkey" FOREIGN KEY ("marketId") REFERENCES "Market"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Swap" ADD CONSTRAINT "Swap_brand0Id_fkey" FOREIGN KEY ("brand0Id") REFERENCES "Brand"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Swap" ADD CONSTRAINT "Swap_brand1Id_fkey" FOREIGN KEY ("brand1Id") REFERENCES "Brand"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Swap" ADD CONSTRAINT "Swap_productCategory0Id_fkey" FOREIGN KEY ("productCategory0Id") REFERENCES "ProductCategory"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Swap" ADD CONSTRAINT "Swap_productCategory1Id_fkey" FOREIGN KEY ("productCategory1Id") REFERENCES "ProductCategory"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Swap" ADD CONSTRAINT "Swap_proposerId_fkey" FOREIGN KEY ("proposerId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Auction" ADD CONSTRAINT "Auction_marketId_fkey" FOREIGN KEY ("marketId") REFERENCES "Market"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Auction" ADD CONSTRAINT "Auction_brandId_fkey" FOREIGN KEY ("brandId") REFERENCES "Brand"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Auction" ADD CONSTRAINT "Auction_productCategoryId_fkey" FOREIGN KEY ("productCategoryId") REFERENCES "ProductCategory"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Auction" ADD CONSTRAINT "Auction_sellerId_fkey" FOREIGN KEY ("sellerId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AuctionComment" ADD CONSTRAINT "AuctionComment_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AuctionComment" ADD CONSTRAINT "AuctionComment_auctionId_fkey" FOREIGN KEY ("auctionId") REFERENCES "Auction"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AuctionComment" ADD CONSTRAINT "AuctionComment_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "AuctionComment"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Bid" ADD CONSTRAINT "Bid_auctionId_fkey" FOREIGN KEY ("auctionId") REFERENCES "Auction"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Bid" ADD CONSTRAINT "Bid_bidderId_fkey" FOREIGN KEY ("bidderId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_MemberToRole" ADD CONSTRAINT "_MemberToRole_A_fkey" FOREIGN KEY ("A") REFERENCES "Member"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_MemberToRole" ADD CONSTRAINT "_MemberToRole_B_fkey" FOREIGN KEY ("B") REFERENCES "Role"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_GuildToRole" ADD CONSTRAINT "_GuildToRole_A_fkey" FOREIGN KEY ("A") REFERENCES "Guild"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_GuildToRole" ADD CONSTRAINT "_GuildToRole_B_fkey" FOREIGN KEY ("B") REFERENCES "Role"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_BrandToGuild" ADD CONSTRAINT "_BrandToGuild_A_fkey" FOREIGN KEY ("A") REFERENCES "Brand"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_BrandToGuild" ADD CONSTRAINT "_BrandToGuild_B_fkey" FOREIGN KEY ("B") REFERENCES "Guild"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/libs/shared/src/prisma/schema.prisma
+++ b/libs/shared/src/prisma/schema.prisma
@@ -9,150 +9,366 @@ generator client {
 }
 
 model User {
-  id              String      @id @default(uuid())
-  createdAt       DateTime    @default(now())
-  updatedAt       DateTime    @updatedAt
-  deleted         Boolean     @default(false)
-  name            String?
-  username        String      @unique
-  socialAccounts  SocialAccount[]
-  avatarURL       String?
-  bot             Boolean     @default(false)
-  roles           Role[]
-  posts           Post[]
-  images          Image[]
-  keywords        Keyword[]
-  sessions        Session[]
+  id                String      @id @default(uuid())
+  createdAt         DateTime    @default(now())
+  updatedAt         DateTime    @updatedAt
+  deletedAt         DateTime?
+  name              String?
+  username          String      @unique
+  socialAccounts    SocialAccount[]
+  avatarURL         String?
+  bot               Boolean     @default(false)
+  members           Member[]
+  sessions          Session[]
+  offers            Offer[]
+  demands           Demand[]
+  swaps             Swap[]
+  auctions          Auction[]
+  bids              Bid[]
+  auctionComments   AuctionComment[]
+  posts             Post[]
+  postComments      PostComment[]
+}
+
+model Member {
+  id                String      @id @default(uuid())
+  createdAt         DateTime    @default(now())
+  updatedAt         DateTime    @updatedAt
+  deletedAt         DateTime?
+  userId            String
+  user              User        @relation(fields: [userId], references: [id])
+  guildId           String
+  guild             Guild       @relation(fields: [guildId], references: [id])
+  roles             Role[]
 }
 
 model SocialAccount {
-  id              String      @id @default(uuid())
-  createdAt       DateTime    @default(now())
-  updatedAt       DateTime    @updatedAt
-  deleted         Boolean     @default(false)
-  provider        String
-  socialId        String
-  userId          String
-  user            User        @relation(fields: [userId], references: [id])
-  refreshToken    String?
-  accessToken     String?
-  expiresAt       Int?
-  tokenType       String?
-  scope           String?
-  idToken         String?
-  sessionState    String?
+  id                String      @id @default(uuid())
+  createdAt         DateTime    @default(now())
+  updatedAt         DateTime    @updatedAt
+  deletedAt         DateTime?
+  provider          String
+  socialId          String
+  userId            String
+  user              User        @relation(fields: [userId], references: [id])
+  refreshToken      String?
+  accessToken       String?
+  expiresAt         Int?
+  tokenType         String?
+  scope             String?
+  idToken           String?
+  sessionState      String?
 
   @@unique([provider, socialId])
 }
 
 model Session {
-  id            String    @id @default(uuid())
-  createdAt     DateTime  @default(now())
-  updatedAt     DateTime  @updatedAt
-  deleted       Boolean   @default(false)
-  sessionToken  String    @unique
-  expires       DateTime
-  userId        String
-  user          User      @relation(fields: [userId], references: [id])
+  id                String      @id @default(uuid())
+  createdAt         DateTime    @default(now())
+  updatedAt         DateTime    @updatedAt
+  deletedAt         DateTime?
+  sessionToken      String      @unique
+  expires           DateTime
+  userId            String
+  user              User        @relation(fields: [userId], references: [id])
 }
 
 model VerificationToken {
-  id            String    @id @default(uuid())
-  createdAt     DateTime  @default(now())
-  updatedAt     DateTime  @updatedAt
-  deleted       Boolean   @default(false)
-  identifier    String
-  token         String    @unique
-  expires       DateTime
+  id                String      @id @default(uuid())
+  createdAt         DateTime    @default(now())
+  updatedAt         DateTime    @updatedAt
+  deletedAt         DateTime?
+  identifier        String
+  token             String      @unique
+  expires           DateTime
 
   @@unique([identifier, token])
 }
 
 model Role {
-  id          String      @id @default(uuid())
-  createdAt   DateTime    @default(now())
-  updateedAt  DateTime    @updatedAt
-  deleted     Boolean     @default(false)
-  name        String      @unique
-  rank        Int?
-  hexColor    String      @default("#000000")
-  users       User[]
+  id                String      @id @default(uuid())
+  createdAt         DateTime    @default(now())
+  updateedAt        DateTime    @updatedAt
+  deletedAt         DateTime?
+  name              String      @unique
+  rank              Int?
+  hexColor          String      @default("#000000")
+  guilds            Guild[]
+  members           Member[]
 }
 
 model Guild {
-  id          String      @id @default(uuid())
-  createdAt   DateTime    @default(now())
-  updateedAt  DateTime    @updatedAt
-  deleted     Boolean     @default(false)
-  name        String      @unique
-  categories  Category[]
-  rank        Int?
+  id                String      @id @default(uuid())
+  createdAt         DateTime    @default(now())
+  updatedAt         DateTime    @updatedAt
+  deletedAt         DateTime?
+  name              String      @unique
+  description       String?
+  icon              String?
+  rank              Int?
+  members           Member[]
+  roles             Role[]
+  market            Market?
+  community         Community?
+  brands            Brand[]
 }
 
-model Category {
-  id          String      @id @default(uuid())
-  createdAt   DateTime    @default(now())
-  updateedAt  DateTime    @updatedAt
-  deleted     Boolean     @default(false)
-  name        String      @unique
-  guildId     String
-  guild       Guild       @relation(fields: [guildId], references: [id])
-  posts       Post[]
-  rank        Int?
+model Market {
+  id                String      @id @default(uuid())
+  createdAt         DateTime    @default(now())
+  updatedAt         DateTime    @updatedAt
+  deletedAt         DateTime?
+  name              String
+  description       String?
+  guildId           String      @unique
+  guild             Guild       @relation(fields: [guildId], references: [id])
+  productCategories ProductCategory[]
+  offers            Offer[]
+  demands           Demand[]
+  swaps             Swap[]
+  auctions          Auction[]
 }
+
+model Community {
+  id                String      @id @default(uuid())
+  createdAt         DateTime    @default(now())
+  updatedAt         DateTime    @updatedAt
+  deletedAt         DateTime?
+  name              String
+  description       String?
+  guildId           String      @unique
+  guild             Guild       @relation(fields: [guildId], references: [id])
+  postCategories    PostCategory[]
+  posts             Post[]
+}
+
+model PostCategory {
+  id                String      @id @default(uuid())
+  createdAt         DateTime    @default(now())
+  updatedAt         DateTime    @updatedAt
+  deletedAt         DateTime?
+  name              String
+  description       String?
+  rank              Int?
+  communityId       String
+  community         Community   @relation(fields: [communityId], references: [id])
+  posts Post[]
+}
+
+model ProductCategory {
+  id                String      @id @default(uuid())
+  createdAt         DateTime    @default(now())
+  updatedAt         DateTime    @updatedAt
+  deletedAt         DateTime?
+  name              String
+  description       String?
+  rank              Int?
+  marketId          String
+  market            Market      @relation(fields: [marketId], references: [id])
+  offers            Offer[]
+  demands           Demand[]
+  swap0s            Swap[]      @relation("Swap0Category")
+  swap1s            Swap[]      @relation("Swap1Category")
+  auctions          Auction[]
+}
+
+model Brand {
+  id                String      @id @default(uuid())
+  createdAt         DateTime    @default(now())
+  updatedAt         DateTime    @updatedAt
+  deletedAt         DateTime?
+  name              String
+  description       String?
+  logo              String?
+  rank              Int?
+  offers            Offer[]
+  demands           Demand[]
+  swap0s            Swap[]      @relation("Swap0Brand")
+  swap1s            Swap[]      @relation("Swap1Brand")
+  auctions          Auction[]
+  guilds            Guild[]
+}
+
+// image
+
+// id String
+// name String
+// size Int
+// url String
+// height Int?
+// width Int?
 
 model Post {
-  id          String      @id @default(uuid())
-  createdAt   DateTime    @default(now())
-  updateedAt  DateTime    @updatedAt
-  deleted     Boolean     @default(false)
-  messageId   String?     @unique
-  type        String
-  title       String
-  subTitle    String?
-  price       Int
-  nego        Boolean?    @default(false)
-  content     String?
-  published   Boolean     @default(false)
-  closed      Boolean     @default(false)
-  userId      String
-  user        User        @relation(fields: [userId], references: [id])
-  categoryId  String
-  category    Category    @relation(fields: [categoryId], references: [id])
-  images      Image[]
-  tags        Tag[]
+  id                String        @id @default(uuid())
+  createdAt         DateTime      @default(now())
+  updatedAt         DateTime      @updatedAt
+  deletedAt         DateTime?
+  title             String
+  content           String
+  communityId       String
+  community         Community     @relation(fields: [communityId], references: [id])
+  postCategoryId    String
+  postCategory      PostCategory  @relation(fields: [postCategoryId], references: [id])
+  authorId          String
+  author            User          @relation(fields: [authorId], references: [id])
+  images            Json[]
+  comments          PostComment[]
 }
 
-model Image {
-  id          String      @id @default(uuid())
-  createdAt   DateTime    @default(now())
-  updateedAt  DateTime    @updatedAt
-  deleted     Boolean     @default(false)
-  name        String
-  size        Int
-  url         String      @unique
-  height      Int?
-  width       Int?
-  userId      String
-  user        User        @relation(fields: [userId], references: [id])
-  postId      String?
-  post        Post?       @relation(fields: [postId], references: [id])
+model PostComment {
+  id                String        @id @default(uuid())
+  createdAt         DateTime      @default(now())
+  updatedAt         DateTime      @updatedAt
+  deletedAt         DateTime?
+  authorId          String
+  author            User          @relation(fields: [authorId], references: [id])
+  content           String
+  postId            String
+  post              Post          @relation(fields: [postId], references: [id])
+  parentId          String?
+  parent            PostComment?  @relation("PostComments", fields: [parentId], references: [id])
+  comments          PostComment[] @relation("PostComments")
 }
 
-model Tag {
-  id          String      @id @default(uuid())
-  createdAt   DateTime    @default(now())
-  updateedAt  DateTime    @updatedAt
-  deleted     Boolean     @default(false)
-  name        String      @unique
-  posts       Post[]
+// product
+
+// name String
+// description String
+// iamges Image[]
+
+model Offer {
+  id                String          @id @default(uuid())
+  createdAt         DateTime        @default(now())
+  updatedAt         DateTime        @updatedAt
+  deletedAt         DateTime?
+  product           Json
+  price             Int
+  priceCurrency     String
+  businessFunction  String
+  marketId          String
+  market            Market          @relation(fields: [marketId], references: [id])
+  brandId           String?
+  brand             Brand?          @relation(fields: [brandId], references: [id])
+  productCategoryId String
+  productCategory   ProductCategory @relation(fields: [productCategoryId], references: [id])
+  sellerId          String
+  seller            User            @relation(fields: [sellerId], references: [id])
+  status            String
 }
 
-model Keyword {
-  id          String      @id @default(uuid())
-  createdAt   DateTime    @default(now())
-  updateedAt  DateTime    @updatedAt
-  deleted     Boolean     @default(false)
-  name        String      @unique
-  users       User[]
+model Demand {
+  id                String          @id @default(uuid())
+  createdAt         DateTime        @default(now())
+  updatedAt         DateTime        @updatedAt
+  deletedAt         DateTime?
+  product           Json
+  price             Int
+  priceCurrency     String
+  businessFunction  String
+  marketId          String
+  market            Market          @relation(fields: [marketId], references: [id])
+  brandId           String?
+  brand             Brand?          @relation(fields: [brandId], references: [id])
+  productCategoryId String
+  productCategory   ProductCategory @relation(fields: [productCategoryId], references: [id])
+  buyerId           String
+  buyer             User            @relation(fields: [buyerId], references: [id])
+  status            String
+}
+
+model Swap {
+  id                  String          @id @default(uuid())
+  createdAt           DateTime        @default(now())
+  updatedAt           DateTime        @updatedAt
+  deletedAt           DateTime?
+  marketId            String
+  market              Market          @relation(fields: [marketId], references: [id])
+  price               Int
+  priceCurrency       String
+  product0            Json
+  product1            Json
+  brand0Id            String?
+  brand0              Brand?          @relation("Swap0Brand", fields: [brand0Id], references: [id])
+  brand1Id            String?
+  brand1              Brand?          @relation("Swap1Brand", fields: [brand1Id], references: [id])
+  productCategory0Id  String
+  productCategory0    ProductCategory @relation("Swap0Category", fields: [productCategory0Id], references: [id])
+  productCategory1Id  String
+  productCategory1    ProductCategory @relation("Swap1Category", fields: [productCategory1Id], references: [id])
+  proposerId          String
+  proposer            User            @relation(fields: [proposerId], references: [id])
+  status              String
+}
+
+model Auction {
+  id                String            @id @default(uuid())
+  createdAt         DateTime          @default(now())
+  updatedAt         DateTime          @updatedAt
+  deletedAt         DateTime?
+  endedAt           DateTime
+  bids              Bid[]  
+  product           Json
+  marketId          String
+  market            Market            @relation(fields: [marketId], references: [id])
+  brandId           String?
+  brand             Brand?            @relation(fields: [brandId], references: [id])
+  productCategoryId String
+  productCategory   ProductCategory   @relation(fields: [productCategoryId], references: [id])
+  sellerId          String
+  seller            User              @relation(fields: [sellerId], references: [id])
+  comments          AuctionComment[]
+  status            String
+}
+
+model AuctionComment {
+  id                String            @id @default(uuid())
+  createdAt         DateTime          @default(now())
+  updatedAt         DateTime          @updatedAt
+  deletedAt         DateTime?
+  authorId          String
+  author            User              @relation(fields: [authorId], references: [id])
+  content           String
+  auctionId         String
+  auction           Auction           @relation(fields: [auctionId], references: [id])
+  parentId          String?
+  parent            AuctionComment?   @relation("AuctionComments", fields: [parentId], references: [id])
+  comments          AuctionComment[]  @relation("AuctionComments")
+}
+
+model Bid {
+  id                String            @id @default(uuid())
+  createdAt         DateTime          @default(now())
+  updatedAt         DateTime          @updatedAt
+  deletedAt         DateTime?
+  canceledAt        DateTime?
+  price             Int
+  priceCurrency     String
+  auctionId         String
+  auction           Auction           @relation(fields: [auctionId], references: [id])
+  bidderId          String
+  bidder            User              @relation(fields: [bidderId], references: [id])
+  status            String
+}
+
+model DiscordChannelLink {
+  discordChannelId  String            @unique
+  discordGuildId    String
+  modelId           String
+  modelName         String
+}
+
+model DiscordMessageLink {
+  discordMessageId  String            @unique
+  discordChannelId  String
+  discordGuildId    String
+  modelId           String
+  modelName         String
+}
+
+model DiscordMarketChannelLink {
+  productCategoryId         String    @unique
+  discordOfferChannelId     String
+  discordDemandChannelId    String
+  discordSwapChannelId      String
+  discordGuildId            String
 }

--- a/libs/shared/src/prisma/seed.ts
+++ b/libs/shared/src/prisma/seed.ts
@@ -11,35 +11,64 @@ async function main() {
     create: {
       name: '키보드',
       rank: 0,
-      categories: {
-        create: [
-          {
-            id: '7f54bdc5-0fe3-4a80-88b4-e3875a821a7f',
-            name: '커스텀',
-            rank: 0,
+      market: {
+        create: {
+          name: '장터',
+          productCategories: {
+            create: [
+              {
+                id: '7f54bdc5-0fe3-4a80-88b4-e3875a821a7f',
+                name: '커스텀',
+                rank: 0,
+              },
+              {
+                id: '68f4937c-64d6-4cd2-9cb1-220f06448608',
+                name: '기성품',
+                rank: 1,
+              },
+              {
+                id: '9ec7c65f-efb3-48a8-be76-47d41ea09280',
+                name: '키캡',
+                rank: 2,
+              },
+              {
+                id: 'ff273177-65cb-41c7-8417-9819582abf24',
+                name: '아티산',
+                rank: 3,
+              },
+              {
+                id: '6464eae0-e4d3-4425-b817-42641436ab5f',
+                name: '기타',
+                rank: 4,
+              },
+            ],
           },
-          {
-            id: '68f4937c-64d6-4cd2-9cb1-220f06448608',
-            name: '기성품',
-            rank: 1,
-          },
-          {
-            id: '9ec7c65f-efb3-48a8-be76-47d41ea09280',
-            name: '키캡',
-            rank: 2,
-          },
-          {
-            id: 'ff273177-65cb-41c7-8417-9819582abf24',
-            name: '아티산',
-            rank: 3,
-          },
-          {
-            id: '6464eae0-e4d3-4425-b817-42641436ab5f',
-            name: '기타',
-            rank: 4,
-          },
-        ],
+        },
       },
+      community: {
+        create: {
+          name: '커뮤니티',
+          postCategories: {
+            create: [
+              {
+                id: '8cb545b1-2f69-4164-bc44-e912d1841e34',
+                name: '사진 영상',
+                rank: 0,
+              },
+              {
+                id: '66fe89c1-c368-4f8d-a757-ecad10dace77',
+                name: '정보 후기',
+                rank: 1,
+              },
+              {
+                id: '7b82c410-7849-4b95-a14c-5bb213a15b3a',
+                name: '거래 후기',
+                rank: 2,
+              },
+            ],
+          },
+        },
+      }
     },
   });
   // eslint-disable-next-line no-console


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
1. discord의 Message를 모두 Post로 처리함에 따라 나오는 복잡성
2. beta 2로의 확장
- 길드, 장터, 커뮤니티, 경매, 멤버

## 어떻게 해결했나요?
1. 디스코드 서버 내의 메시지를 각각 다른 model 로 분리
- Offer, Demand, Swap, Auction, Post
2. 새로운 schema 정의와 이를 테스트하기 위한 test db 생성

## 참고 자료
https://github.com/guheyo/guheyo-server/wiki/ERD