### PR TITLE
feat: add an incoming port to the user application

### DIFF
--- a/libs/domains/src/user/application/port/in/member.command.usecase.ts
+++ b/libs/domains/src/user/application/port/in/member.command.usecase.ts
@@ -1,0 +1,6 @@
+import { MemberCreateRequest } from './member.create.request';
+import { MemberResponse } from './member.response';
+
+export interface MemberCommandUseCase {
+  create(request: MemberCreateRequest): Promise<MemberResponse>;
+}

--- a/libs/domains/src/user/application/port/in/member.create.request.ts
+++ b/libs/domains/src/user/application/port/in/member.create.request.ts
@@ -1,0 +1,8 @@
+import { PickType } from '@nestjs/swagger';
+import { MemberEntity } from '@lib/domains/user/domain/member.entity';
+
+export class MemberCreateRequest extends PickType(MemberEntity, [
+  'userId',
+  'guildId',
+  'roles',
+] as const) {}

--- a/libs/domains/src/user/application/port/in/member.response.ts
+++ b/libs/domains/src/user/application/port/in/member.response.ts
@@ -1,0 +1,8 @@
+import { OmitType } from '@nestjs/swagger';
+import { MemberEntity } from '@lib/domains/user/domain/member.entity';
+
+export class MemberResponse extends OmitType(MemberEntity, [
+  'id',
+  'updatedAt',
+  'deletedAt',
+] as const) {}

--- a/libs/domains/src/user/application/port/in/session.command.usecase.ts
+++ b/libs/domains/src/user/application/port/in/session.command.usecase.ts
@@ -3,7 +3,7 @@ import { SessionUpdateRequest } from './session.update.request';
 import { SessionResponse } from './session.response';
 
 export interface SessionCommandUseCase {
-  create(sessionCreateRequest: SessionCreateRequest): Promise<SessionResponse>;
-  update(sessionUpdateRequest: SessionUpdateRequest): Promise<SessionResponse>;
+  create(request: SessionCreateRequest): Promise<SessionResponse>;
+  update(request: SessionUpdateRequest): Promise<SessionResponse>;
   delete(userId: string, sessionToken: string): void;
 }

--- a/libs/domains/src/user/application/port/in/session.command.usecase.ts
+++ b/libs/domains/src/user/application/port/in/session.command.usecase.ts
@@ -1,0 +1,9 @@
+import { SessionCreateRequest } from './session.create.request';
+import { SessionUpdateRequest } from './session.update.request';
+import { SessionResponse } from './session.response';
+
+export interface SessionCommandUseCase {
+  create(sessionCreateRequest: SessionCreateRequest): Promise<SessionResponse>;
+  update(sessionUpdateRequest: SessionUpdateRequest): Promise<SessionResponse>;
+  delete(userId: string, sessionToken: string): void;
+}

--- a/libs/domains/src/user/application/port/in/session.create.request.ts
+++ b/libs/domains/src/user/application/port/in/session.create.request.ts
@@ -1,0 +1,8 @@
+import { PickType } from '@nestjs/swagger';
+import { SessionEntity } from '@lib/domains/user/domain/session.entity';
+
+export class SessionCreateRequest extends PickType(SessionEntity, [
+  'sessionToken',
+  'expires',
+  'userId',
+] as const) {}

--- a/libs/domains/src/user/application/port/in/session.query.usecase.ts
+++ b/libs/domains/src/user/application/port/in/session.query.usecase.ts
@@ -1,0 +1,5 @@
+import { SessionAndUserResponse } from './session.session-and-user.response';
+
+export interface SessionQueryUseCase {
+  getSessionAndUser(userId: string, sessionToken: string): Promise<SessionAndUserResponse | null>;
+}

--- a/libs/domains/src/user/application/port/in/session.response.ts
+++ b/libs/domains/src/user/application/port/in/session.response.ts
@@ -1,0 +1,8 @@
+import { PickType } from '@nestjs/swagger';
+import { SessionEntity } from '@lib/domains/user/domain/session.entity';
+
+export class SessionResponse extends PickType(SessionEntity, [
+  'sessionToken',
+  'expires',
+  'userId',
+] as const) {}

--- a/libs/domains/src/user/application/port/in/session.session-and-user.response.ts
+++ b/libs/domains/src/user/application/port/in/session.session-and-user.response.ts
@@ -1,0 +1,8 @@
+import { SessionResponse } from './session.response';
+import { UserResponse } from './user.response';
+
+export class SessionAndUserResponse {
+  session: SessionResponse;
+
+  user: UserResponse;
+}

--- a/libs/domains/src/user/application/port/in/session.update.request.ts
+++ b/libs/domains/src/user/application/port/in/session.update.request.ts
@@ -1,0 +1,8 @@
+import { PickType } from '@nestjs/swagger';
+import { SessionEntity } from '@lib/domains/user/domain/session.entity';
+
+export class SessionUpdateRequest extends PickType(SessionEntity, [
+  'sessionToken',
+  'expires',
+  'userId',
+] as const) {}

--- a/libs/domains/src/user/application/port/in/social-account.command.usecase.ts
+++ b/libs/domains/src/user/application/port/in/social-account.command.usecase.ts
@@ -2,6 +2,6 @@ import { SessionCreateRequest } from './session.create.request';
 import { SessionResponse } from './session.response';
 
 export interface SocialAccountCommandUseCase {
-  create(userId: string, sessionCreateRequest: SessionCreateRequest): Promise<SessionResponse>;
+  create(sessionCreateRequest: SessionCreateRequest): Promise<SessionResponse>;
   delete(userId: string, provider: string, socialId: string): Promise<SessionResponse>;
 }

--- a/libs/domains/src/user/application/port/in/social-account.command.usecase.ts
+++ b/libs/domains/src/user/application/port/in/social-account.command.usecase.ts
@@ -2,6 +2,6 @@ import { SessionCreateRequest } from './session.create.request';
 import { SessionResponse } from './session.response';
 
 export interface SocialAccountCommandUseCase {
-  create(sessionCreateRequest: SessionCreateRequest): Promise<SessionResponse>;
+  create(request: SessionCreateRequest): Promise<SessionResponse>;
   delete(userId: string, provider: string, socialId: string): Promise<SessionResponse>;
 }

--- a/libs/domains/src/user/application/port/in/social-account.command.usecase.ts
+++ b/libs/domains/src/user/application/port/in/social-account.command.usecase.ts
@@ -1,0 +1,7 @@
+import { SessionCreateRequest } from './session.create.request';
+import { SessionResponse } from './session.response';
+
+export interface SocialAccountCommandUseCase {
+  create(userId: string, sessionCreateRequest: SessionCreateRequest): Promise<SessionResponse>;
+  delete(userId: string, provider: string, socialId: string): Promise<SessionResponse>;
+}

--- a/libs/domains/src/user/application/port/in/social-account.create.request.ts
+++ b/libs/domains/src/user/application/port/in/social-account.create.request.ts
@@ -1,0 +1,15 @@
+import { PickType } from '@nestjs/swagger';
+import { SocialAccountEntity } from '@lib/domains/user/domain/social-account.entity';
+
+export class SocialAccountCreateRequest extends PickType(SocialAccountEntity, [
+  'provider',
+  'socialId',
+  'userId',
+  'refreshToken',
+  'accessToken',
+  'expiresAt',
+  'tokenType',
+  'scope',
+  'idToken',
+  'sessionState',
+] as const) {}

--- a/libs/domains/src/user/application/port/in/social-account.response.ts
+++ b/libs/domains/src/user/application/port/in/social-account.response.ts
@@ -1,0 +1,8 @@
+import { OmitType } from '@nestjs/swagger';
+import { SocialAccountEntity } from '@lib/domains/user/domain/social-account.entity';
+
+export class SocialAccountResponse extends OmitType(SocialAccountEntity, [
+  'id',
+  'updatedAt',
+  'deletedAt',
+] as const) {}

--- a/libs/domains/src/user/application/port/in/user.command.usecase.ts
+++ b/libs/domains/src/user/application/port/in/user.command.usecase.ts
@@ -3,7 +3,7 @@ import { UserUpdateRequest } from './user.update.request';
 import { UserResponse } from './user.response';
 
 export interface UserCommandUseCase {
-  create(userCreateRequest: UserCreateRequest): Promise<UserResponse | null>;
-  update(userUpdateRequest: UserUpdateRequest): Promise<UserResponse | null>;
+  create(request: UserCreateRequest): Promise<UserResponse | null>;
+  update(request: UserUpdateRequest): Promise<UserResponse | null>;
   delete(id: string): void;
 }

--- a/libs/domains/src/user/application/port/in/user.command.usecase.ts
+++ b/libs/domains/src/user/application/port/in/user.command.usecase.ts
@@ -1,0 +1,9 @@
+import { UserCreateRequest } from './user.create.request';
+import { UserUpdateRequest } from './user.update.request';
+import { UserResponse } from './user.response';
+
+export interface UserCommandUseCase {
+  create(userCreateRequest: UserCreateRequest): Promise<UserResponse | null>;
+  update(userUpdateRequest: UserUpdateRequest): Promise<UserResponse | null>;
+  delete(id: string): void;
+}

--- a/libs/domains/src/user/application/port/in/user.create.request.ts
+++ b/libs/domains/src/user/application/port/in/user.create.request.ts
@@ -1,0 +1,4 @@
+import { PickType } from '@nestjs/swagger';
+import { UserEntity } from '@lib/domains/user/domain/user.entity';
+
+export class UserCreateRequest extends PickType(UserEntity, ['username'] as const) {}

--- a/libs/domains/src/user/application/port/in/user.query.usecase.ts
+++ b/libs/domains/src/user/application/port/in/user.query.usecase.ts
@@ -1,0 +1,6 @@
+import { UserResponse } from './user.response';
+
+export interface UserQueryUseCase {
+  getUserById(id: string): Promise<UserResponse | null>;
+  getUserBySocialAccount(provider: string, socialId: string): Promise<UserResponse | null>;
+}

--- a/libs/domains/src/user/application/port/in/user.response.ts
+++ b/libs/domains/src/user/application/port/in/user.response.ts
@@ -1,0 +1,4 @@
+import { OmitType } from '@nestjs/swagger';
+import { UserEntity } from '@lib/domains/user/domain/user.entity';
+
+export class UserResponse extends OmitType(UserEntity, ['updatedAt', 'deletedAt'] as const) {}

--- a/libs/domains/src/user/application/port/in/user.update.request.ts
+++ b/libs/domains/src/user/application/port/in/user.update.request.ts
@@ -1,0 +1,4 @@
+import { PickType } from '@nestjs/swagger';
+import { UserEntity } from '@lib/domains/user/domain/user.entity';
+
+export class UserUpdateRequest extends PickType(UserEntity, ['name', 'avatarURL'] as const) {}


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
1. user application의 incomming port 구현

## 어떻게 해결했나요?
1. request, response class 정의
2. command, query의 use case interface 정의
- use case 각각을 하나의 interface로 만드는 것이 정석이나, 편의상 aggregate의 entity 별로 command와 query use case class를 하나씩 정의
- command에는 CUD, query에는 R 를 모아둠
- 기본적인 CRUD외의 복잡한 use case가 생길 경우, 별도의 file에 정의할 계획

## 참고 자료
https://nodejs.myeongjae.kim/pages/002-hexagonal-architecture/