### PR TITLE
feat: change user command usecase to command and handler

### DIFF
--- a/libs/domains/src/user/application/commands/social-account/social-account.create.command.ts
+++ b/libs/domains/src/user/application/commands/social-account/social-account.create.command.ts
@@ -1,0 +1,18 @@
+import { PickType } from '@nestjs/swagger';
+import { ICommand } from '@nestjs/cqrs';
+import { SocialAccountEntity } from '@lib/domains/user/domain/social-account.entity';
+
+export class SocialAccountCreateCommand
+  extends PickType(SocialAccountEntity, [
+    'provider',
+    'socialId',
+    'userId',
+    'refreshToken',
+    'accessToken',
+    'expiresAt',
+    'tokenType',
+    'scope',
+    'idToken',
+    'sessionState',
+  ] as const)
+  implements ICommand {}

--- a/libs/domains/src/user/application/commands/social-account/social-account.delete.command.ts
+++ b/libs/domains/src/user/application/commands/social-account/social-account.delete.command.ts
@@ -1,0 +1,9 @@
+import { ICommand } from '@nestjs/cqrs';
+
+export class SocialAccountDeleteCommand implements ICommand {
+  constructor(
+    public readonly userId: string,
+    public readonly provider: string,
+    public readonly socialId: string,
+  ) {}
+}

--- a/libs/domains/src/user/application/commands/social-account/social-account.update.command.ts
+++ b/libs/domains/src/user/application/commands/social-account/social-account.update.command.ts
@@ -1,0 +1,18 @@
+import { PickType } from '@nestjs/swagger';
+import { ICommand } from '@nestjs/cqrs';
+import { SocialAccountEntity } from '@lib/domains/user/domain/social-account.entity';
+
+export class SocialAccountUpdateCommand
+  extends PickType(SocialAccountEntity, [
+    'provider',
+    'socialId',
+    'userId',
+    'refreshToken',
+    'accessToken',
+    'expiresAt',
+    'tokenType',
+    'scope',
+    'idToken',
+    'sessionState',
+  ] as const)
+  implements ICommand {}

--- a/libs/domains/src/user/application/commands/user-create/__tests__/user.create.handler.spec.ts
+++ b/libs/domains/src/user/application/commands/user-create/__tests__/user.create.handler.spec.ts
@@ -1,0 +1,34 @@
+import { Test } from '@nestjs/testing';
+import { mock, verify, instance, anyOfClass } from 'ts-mockito';
+import { UserCommandAdapter } from '@lib/domains/user/adapter/out/persistence/user.command.adapter';
+import { UserEntity } from '@lib/domains/user/domain/user.entity';
+import { UserSavePort } from '../../../port/out/user.save.port';
+import { UserCreateCommand } from '../user.create.command';
+import { UserCreateHandler } from '../user.create.handler';
+
+describe('UserCreateCommand', () => {
+  let handler: UserCreateHandler;
+  const savePort: UserSavePort = mock(UserCommandAdapter);
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        UserCreateHandler,
+        {
+          provide: 'UserSavePort',
+          useValue: instance(savePort),
+        },
+      ],
+    }).compile();
+
+    handler = moduleRef.get<UserCreateHandler>(UserCreateHandler);
+  });
+
+  describe('execute', () => {
+    it('should execute create', async () => {
+      const command: UserCreateCommand = { username: 'test-user' };
+      await handler.execute(command);
+      verify(savePort.create(anyOfClass(UserEntity))).once();
+    });
+  });
+});

--- a/libs/domains/src/user/application/commands/user-create/user.create.command.ts
+++ b/libs/domains/src/user/application/commands/user-create/user.create.command.ts
@@ -1,0 +1,7 @@
+import { PickType } from '@nestjs/swagger';
+import { ICommand } from '@nestjs/cqrs';
+import { UserEntity } from '@lib/domains/user/domain/user.entity';
+
+export class UserCreateCommand
+  extends PickType(UserEntity, ['username'] as const)
+  implements ICommand {}

--- a/libs/domains/src/user/application/commands/user-create/user.create.handler.ts
+++ b/libs/domains/src/user/application/commands/user-create/user.create.handler.ts
@@ -1,0 +1,15 @@
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { Inject } from '@nestjs/common';
+import { UserEntity } from '@lib/domains/user/domain/user.entity';
+import { UserCreateCommand } from './user.create.command';
+import { UserSavePort } from '../../port/out/user.save.port';
+
+@CommandHandler(UserCreateCommand)
+export class UserCreateHandler implements ICommandHandler<UserCreateCommand> {
+  constructor(@Inject('UserSavePort') private userSavePort: UserSavePort) {}
+
+  async execute(command: UserCreateCommand): Promise<void> {
+    const user = new UserEntity(command);
+    await this.userSavePort.create(user);
+  }
+}

--- a/libs/domains/src/user/application/commands/user-delete/__tests__/user.delete.handler.spec.ts
+++ b/libs/domains/src/user/application/commands/user-delete/__tests__/user.delete.handler.spec.ts
@@ -1,0 +1,32 @@
+import { Test } from '@nestjs/testing';
+import { mock, verify, instance } from 'ts-mockito';
+import { UserCommandAdapter } from '@lib/domains/user/adapter/out/persistence/user.command.adapter';
+import { UserSavePort } from '../../../port/out/user.save.port';
+import { UserDeleteCommand } from '../user.delete.command';
+import { UserDeleteHandler } from '../user.delete.handler';
+
+describe('UserDeleteCommand', () => {
+  let handler: UserDeleteHandler;
+  const savePort: UserSavePort = mock(UserCommandAdapter);
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        UserDeleteHandler,
+        {
+          provide: 'UserSavePort',
+          useValue: instance(savePort),
+        },
+      ],
+    }).compile();
+    handler = moduleRef.get<UserDeleteHandler>(UserDeleteHandler);
+  });
+
+  describe('execute', () => {
+    it('should execute delete', async () => {
+      const command: UserDeleteCommand = { id: '1' };
+      await handler.execute(command);
+      verify(savePort.delete(command.id)).once();
+    });
+  });
+});

--- a/libs/domains/src/user/application/commands/user-delete/user.delete.command.ts
+++ b/libs/domains/src/user/application/commands/user-delete/user.delete.command.ts
@@ -1,0 +1,5 @@
+import { ICommand } from '@nestjs/cqrs';
+
+export class UserDeleteCommand implements ICommand {
+  constructor(public readonly id: string) {}
+}

--- a/libs/domains/src/user/application/commands/user-delete/user.delete.handler.ts
+++ b/libs/domains/src/user/application/commands/user-delete/user.delete.handler.ts
@@ -1,0 +1,13 @@
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { Inject } from '@nestjs/common';
+import { UserDeleteCommand } from './user.delete.command';
+import { UserSavePort } from '../../port/out/user.save.port';
+
+@CommandHandler(UserDeleteCommand)
+export class UserDeleteHandler implements ICommandHandler<UserDeleteCommand> {
+  constructor(@Inject('UserSavePort') private userSavePort: UserSavePort) {}
+
+  async execute(command: UserDeleteCommand): Promise<void> {
+    await this.userSavePort.delete(command.id);
+  }
+}

--- a/libs/domains/src/user/application/commands/user-update/__tests__/user.update.handler.spec.ts
+++ b/libs/domains/src/user/application/commands/user-update/__tests__/user.update.handler.spec.ts
@@ -1,0 +1,33 @@
+import { Test } from '@nestjs/testing';
+import { mock, verify, instance, anyOfClass } from 'ts-mockito';
+import { UserCommandAdapter } from '@lib/domains/user/adapter/out/persistence/user.command.adapter';
+import { UserEntity } from '@lib/domains/user/domain/user.entity';
+import { UserSavePort } from '../../../port/out/user.save.port';
+import { UserUpdateCommand } from '../user.update.command';
+import { UserUpdateHandler } from '../user.update.handler';
+
+describe('UserUpdateCommand', () => {
+  let handler: UserUpdateHandler;
+  const savePort: UserSavePort = mock(UserCommandAdapter);
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        UserUpdateHandler,
+        {
+          provide: 'UserSavePort',
+          useValue: instance(savePort),
+        },
+      ],
+    }).compile();
+    handler = moduleRef.get<UserUpdateHandler>(UserUpdateHandler);
+  });
+
+  describe('execute', () => {
+    it('should execute update', async () => {
+      const command: UserUpdateCommand = { name: 'changed-name' };
+      await handler.execute(command);
+      verify(savePort.update(anyOfClass(UserEntity))).once();
+    });
+  });
+});

--- a/libs/domains/src/user/application/commands/user-update/user.update.command.ts
+++ b/libs/domains/src/user/application/commands/user-update/user.update.command.ts
@@ -1,0 +1,7 @@
+import { PartialType, PickType } from '@nestjs/swagger';
+import { ICommand } from '@nestjs/cqrs';
+import { UserEntity } from '@lib/domains/user/domain/user.entity';
+
+export class UserUpdateCommand
+  extends PartialType(PickType(UserEntity, ['name', 'avatarURL'] as const))
+  implements ICommand {}

--- a/libs/domains/src/user/application/commands/user-update/user.update.handler.ts
+++ b/libs/domains/src/user/application/commands/user-update/user.update.handler.ts
@@ -1,0 +1,15 @@
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { Inject } from '@nestjs/common';
+import { UserEntity } from '@lib/domains/user/domain/user.entity';
+import { UserUpdateCommand } from './user.update.command';
+import { UserSavePort } from '../../port/out/user.save.port';
+
+@CommandHandler(UserUpdateCommand)
+export class UserUpdateHandler implements ICommandHandler<UserUpdateCommand> {
+  constructor(@Inject('UserSavePort') private userSavePort: UserSavePort) {}
+
+  async execute(command: UserUpdateCommand): Promise<void> {
+    const user = new UserEntity(command);
+    await this.userSavePort.update(user);
+  }
+}

--- a/libs/domains/src/user/application/port/in/user.command.usecase.ts
+++ b/libs/domains/src/user/application/port/in/user.command.usecase.ts
@@ -1,9 +1,0 @@
-import { UserCreateRequest } from './user.create.request';
-import { UserUpdateRequest } from './user.update.request';
-import { UserResponse } from './user.response';
-
-export interface UserCommandUseCase {
-  create(request: UserCreateRequest): Promise<UserResponse | null>;
-  update(request: UserUpdateRequest): Promise<UserResponse | null>;
-  delete(id: string): void;
-}

--- a/libs/domains/src/user/application/port/in/user.create.request.ts
+++ b/libs/domains/src/user/application/port/in/user.create.request.ts
@@ -1,4 +1,0 @@
-import { PickType } from '@nestjs/swagger';
-import { UserEntity } from '@lib/domains/user/domain/user.entity';
-
-export class UserCreateRequest extends PickType(UserEntity, ['username'] as const) {}

--- a/libs/domains/src/user/application/port/in/user.update.request.ts
+++ b/libs/domains/src/user/application/port/in/user.update.request.ts
@@ -1,4 +1,0 @@
-import { PickType } from '@nestjs/swagger';
-import { UserEntity } from '@lib/domains/user/domain/user.entity';
-
-export class UserUpdateRequest extends PickType(UserEntity, ['name', 'avatarURL'] as const) {}


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
하위 relation들을 불러오는 query로 인해 command 까지 복잡해지는 현상

## 어떻게 해결했나요?
1. in port로 연결되는 기존의 구조를 CQRS로 전환
2. request -> command
3. use case를 구현하는 service -> command handler

## 참고 자료
https://docs.nestjs.com/recipes/cqrs
https://github.com/kyhsa93/nestjs-rest-cqrs-example