### PR TITLE
feat: change delete parameters to command, getBySocialAccount parameters to query 

### DIFF
--- a/libs/domains/src/user/adapter/out/persistence/social-account.command.adapter.ts
+++ b/libs/domains/src/user/adapter/out/persistence/social-account.command.adapter.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { SocialAccountSavePort } from '@lib/domains/user/application/port/out/social-account.save.port';
 import { SocialAccountEntity } from '@lib/domains/user/domain/social-account.entity';
+import { SocialAccountDeleteCommand } from '@lib/domains/user/application/command/social-account-delete/social-account.delete.command';
 import { UserCommandRepository } from './user.command.repository';
 
 @Injectable()
@@ -15,7 +16,7 @@ export class SocialAccountCommandAdapter implements SocialAccountSavePort {
     await this.repository.updateSocialAccount(socialAccount);
   }
 
-  async delete(userId: string, provider: string, socialId: string): Promise<void> {
-    await this.repository.deleteSocialAccount(userId, provider, socialId);
+  async delete(command: SocialAccountDeleteCommand): Promise<void> {
+    await this.repository.deleteSocialAccount(command);
   }
 }

--- a/libs/domains/src/user/adapter/out/persistence/user.command.repository.ts
+++ b/libs/domains/src/user/adapter/out/persistence/user.command.repository.ts
@@ -2,6 +2,7 @@ import { SocialAccountEntity } from '@lib/domains/user/domain/social-account.ent
 import { UserEntity } from '@lib/domains/user/domain/user.entity';
 import { PrismaService } from '@lib/shared';
 import { Injectable } from '@nestjs/common';
+import { SocialAccountDeleteCommand } from '@lib/domains/user/application/command/social-account-delete/social-account.delete.command';
 import _ from 'lodash';
 
 @Injectable()
@@ -91,16 +92,16 @@ export class UserCommandRepository {
     });
   }
 
-  async deleteSocialAccount(userId: string, provider: string, socialId: string): Promise<void> {
+  async deleteSocialAccount(command: SocialAccountDeleteCommand): Promise<void> {
     await this.prismaService.user.update({
       where: {
-        id: userId,
+        id: command.userId,
       },
       data: {
         socialAccounts: {
           deleteMany: {
-            provider,
-            socialId,
+            provider: command.provider,
+            socialId: command.socialId,
           },
         },
       },

--- a/libs/domains/src/user/adapter/out/persistence/user.query.adapter.ts
+++ b/libs/domains/src/user/adapter/out/persistence/user.query.adapter.ts
@@ -12,6 +12,6 @@ export class UserQueryAdapter implements UserLoadPort {
   }
 
   async getBySocailAccount(provider: string, socialId: string): Promise<UserEntity | null> {
-    return this.getBySocailAccount(provider, socialId);
+    return this.repository.getBySocialAccount(provider, socialId);
   }
 }

--- a/libs/domains/src/user/adapter/out/persistence/user.query.adapter.ts
+++ b/libs/domains/src/user/adapter/out/persistence/user.query.adapter.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { UserLoadPort } from '@lib/domains/user/application/port/out/user.load.port';
 import { UserEntity } from '@lib/domains/user/domain/user.entity';
+import { UserGetBySocialAccountQuery } from '@lib/domains/user/application/query/user-get-by-social-account/user.get-by-social-account.query';
 import { UserQueryRepository } from './user.query.repository';
 
 @Injectable()
@@ -11,7 +12,7 @@ export class UserQueryAdapter implements UserLoadPort {
     return this.repository.getById(id);
   }
 
-  async getBySocailAccount(provider: string, socialId: string): Promise<UserEntity | null> {
-    return this.repository.getBySocialAccount(provider, socialId);
+  async getBySocailAccount(query: UserGetBySocialAccountQuery): Promise<UserEntity | null> {
+    return this.repository.getBySocialAccount(query);
   }
 }

--- a/libs/domains/src/user/adapter/out/persistence/user.query.repository.ts
+++ b/libs/domains/src/user/adapter/out/persistence/user.query.repository.ts
@@ -2,6 +2,7 @@ import { UserEntity } from '@lib/domains/user/domain/user.entity';
 import { PrismaService } from '@lib/shared';
 import { Injectable } from '@nestjs/common';
 import _ from 'lodash';
+import { UserGetBySocialAccountQuery } from '@lib/domains/user/application/query/user-get-by-social-account/user.get-by-social-account.query';
 
 @Injectable()
 export class UserQueryRepository {
@@ -22,13 +23,13 @@ export class UserQueryRepository {
     return user ? new UserEntity(user) : null;
   }
 
-  async getBySocialAccount(provider: string, socialId: string): Promise<UserEntity | null> {
+  async getBySocialAccount(query: UserGetBySocialAccountQuery): Promise<UserEntity | null> {
     const users = await this.prismaService.user.findMany({
       where: {
         socialAccounts: {
           some: {
-            provider,
-            socialId,
+            provider: query.provider,
+            socialId: query.socialId,
           },
         },
       },

--- a/libs/domains/src/user/adapter/out/persistence/user.query.repository.ts
+++ b/libs/domains/src/user/adapter/out/persistence/user.query.repository.ts
@@ -1,7 +1,6 @@
 import { UserEntity } from '@lib/domains/user/domain/user.entity';
 import { PrismaService } from '@lib/shared';
 import { Injectable } from '@nestjs/common';
-import _ from 'lodash';
 import { UserGetBySocialAccountQuery } from '@lib/domains/user/application/query/user-get-by-social-account/user.get-by-social-account.query';
 
 @Injectable()

--- a/libs/domains/src/user/application/command/social-account-create/social-account.create.handler.ts
+++ b/libs/domains/src/user/application/command/social-account-create/social-account.create.handler.ts
@@ -6,7 +6,8 @@ import { SocialAccountSavePort } from '../../port/out/social-account.save.port';
 
 @CommandHandler(SocialAccountCreateCommand)
 export class SocialAccountCreateHandler implements ICommandHandler<SocialAccountCreateCommand> {
-  constructor(@Inject('SocialAccountSavePort')
+  constructor(
+    @Inject('SocialAccountSavePort')
     private socialAccountSavePort: SocialAccountSavePort,
   ) {}
 

--- a/libs/domains/src/user/application/command/social-account-delete/__tests__/social-account.delete.handler.spec.ts
+++ b/libs/domains/src/user/application/command/social-account-delete/__tests__/social-account.delete.handler.spec.ts
@@ -31,7 +31,7 @@ describe('SocialAccountDeleteCommand', () => {
         userId: 'user-id',
       };
       await handler.execute(command);
-      verify(savePort.delete(command.userId, command.provider, command.socialId));
+      verify(savePort.delete(command)).once();
     });
   });
 });

--- a/libs/domains/src/user/application/command/social-account-delete/social-account.delete.handler.ts
+++ b/libs/domains/src/user/application/command/social-account-delete/social-account.delete.handler.ts
@@ -10,6 +10,6 @@ export class SocialAccountDeleteHandler implements ICommandHandler<SocialAccount
   ) {}
 
   async execute(command: SocialAccountDeleteCommand): Promise<void> {
-    await this.socialAccountSavePort.delete(command.userId, command.provider, command.socialId);
+    await this.socialAccountSavePort.delete(command);
   }
 }

--- a/libs/domains/src/user/application/command/social-account-delete/social-account.delete.handler.ts
+++ b/libs/domains/src/user/application/command/social-account-delete/social-account.delete.handler.ts
@@ -5,7 +5,8 @@ import { SocialAccountSavePort } from '../../port/out/social-account.save.port';
 
 @CommandHandler(SocialAccountDeleteCommand)
 export class SocialAccountDeleteHandler implements ICommandHandler<SocialAccountDeleteCommand> {
-  constructor(@Inject('SocialAccountSavePort')
+  constructor(
+    @Inject('SocialAccountSavePort')
     private socialAccountSavePort: SocialAccountSavePort,
   ) {}
 

--- a/libs/domains/src/user/application/command/social-account-update/social-account.update.handler.ts
+++ b/libs/domains/src/user/application/command/social-account-update/social-account.update.handler.ts
@@ -6,7 +6,8 @@ import { SocialAccountSavePort } from '../../port/out/social-account.save.port';
 
 @CommandHandler(SocialAccountUpdateCommand)
 export class SocialAccountUpdateHandler implements ICommandHandler<SocialAccountUpdateCommand> {
-  constructor(@Inject('SocialAccountSavePort')
+  constructor(
+    @Inject('SocialAccountSavePort')
     private socialAccountSavePort: SocialAccountSavePort,
   ) {}
 

--- a/libs/domains/src/user/application/port/out/social-account.save.port.ts
+++ b/libs/domains/src/user/application/port/out/social-account.save.port.ts
@@ -1,7 +1,8 @@
 import { SocialAccountEntity } from '@lib/domains/user/domain/social-account.entity';
+import { SocialAccountDeleteCommand } from '../../command/social-account-delete/social-account.delete.command';
 
 export interface SocialAccountSavePort {
   create(socialAccount: SocialAccountEntity): Promise<void>;
   update(socialAccount: SocialAccountEntity): Promise<void>;
-  delete(userId: string, provider: string, socialId: string): Promise<void>;
+  delete(command: SocialAccountDeleteCommand): Promise<void>;
 }

--- a/libs/domains/src/user/application/port/out/user.load.port.ts
+++ b/libs/domains/src/user/application/port/out/user.load.port.ts
@@ -1,6 +1,7 @@
 import { UserEntity } from '@lib/domains/user/domain/user.entity';
+import { UserGetBySocialAccountQuery } from '../../query/user-get-by-social-account/user.get-by-social-account.query';
 
 export interface UserLoadPort {
   getById(id: string): Promise<UserEntity | null>;
-  getBySocailAccount(provider: string, socialId: string): Promise<UserEntity | null>;
+  getBySocailAccount(query: UserGetBySocialAccountQuery): Promise<UserEntity | null>;
 }

--- a/libs/domains/src/user/application/query/user-get-by-social-account/__tests__/user.get-by-social-account.handler.spec.ts
+++ b/libs/domains/src/user/application/query/user-get-by-social-account/__tests__/user.get-by-social-account.handler.spec.ts
@@ -19,6 +19,7 @@ describe('UserGetBySocialAccountQuery', () => {
         },
       ],
     }).compile();
+
     handler = moduleRef.get<UserGetBySocialAccountHandler>(UserGetBySocialAccountHandler);
   });
 
@@ -26,7 +27,7 @@ describe('UserGetBySocialAccountQuery', () => {
     it('should execute getBySocailAccount', async () => {
       const query: UserGetBySocialAccountQuery = { provider: 'discord', socialId: 'social-id' };
       await handler.execute(query);
-      verify(loadPort.getBySocailAccount(query.provider, query.socialId)).once();
+      verify(loadPort.getBySocailAccount(query)).once();
     });
   });
 });

--- a/libs/domains/src/user/application/query/user-get-by-social-account/user.get-by-social-account.handler.ts
+++ b/libs/domains/src/user/application/query/user-get-by-social-account/user.get-by-social-account.handler.ts
@@ -9,6 +9,6 @@ export class UserGetBySocialAccountHandler implements IQueryHandler<UserGetBySoc
   constructor(@Inject('UserLoadPort') private userLoadPort: UserLoadPort) {}
 
   async execute(query: UserGetBySocialAccountQuery): Promise<UserEntity | null> {
-    return this.userLoadPort.getBySocailAccount(query.provider, query.socialId);
+    return this.userLoadPort.getBySocailAccount(query);
   }
 }


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
delete, getBySocialAccount의 parameters를 각각 값으로 넘길 경우, 입력하는 순서가 달라질 경우 오류 발생

## 어떻게 해결했나요?
1. delete -> command 그대로 넘기기
2. getBySocialAccount -> query 그대로 넘기기

## Issue
1. command와 query를 그대로 넘길 경우, controller, handler, adapter, repository 간의 의존성을 높일 수 있음
2. 필요할 경우 controller - handler / handler - adapter / adapter- repository에서의 DTO를 각각 구분
3. 현상황에서는 이를 나누는 것이 불필요함