### PR TITLE
feat: save user data using discord slash command

### DIFF
--- a/apps/bot/package.json
+++ b/apps/bot/package.json
@@ -8,6 +8,7 @@
     "@nestjs/common": "^10.2.5",
     "@nestjs/config": "^3.0.0",
     "@nestjs/core": "^10.2.5",
+    "@nestjs/cqrs": "^10.2.5",
     "@nestjs/platform-fastify": "^10.1.2",
     "@nestjs/swagger": "^7.1.6",
     "axios": "^1.4.0",
@@ -24,7 +25,8 @@
     "path": "^0.12.7",
     "redis": "^4.6.7",
     "reflect-metadata": "^0.1.13",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.1.10",
@@ -34,6 +36,7 @@
     "@types/express": "^4.17.17",
     "@types/js-yaml": "^4.0.5",
     "@types/lodash": "^4.14.196",
+    "@types/uuid": "^9.0.4",
     "cross-env": "^7.0.3",
     "supertest": "^6.3.3",
     "typescript": "^5.1.6"

--- a/apps/bot/src/bot.module.ts
+++ b/apps/bot/src/bot.module.ts
@@ -1,13 +1,18 @@
 import { Module } from '@nestjs/common';
+import { CqrsModule } from '@nestjs/cqrs';
 import { ConfigYamlModule } from '@app/bot/config/config.module';
 import { NecordModule } from 'necord';
 import { ConfigService } from '@nestjs/config/dist';
+import { UserCommandModule } from '@lib/domains/user/application/commands/user.command.module';
+import { UserEventModule } from '@lib/domains/user/application/events/user.event.module';
+import { UserSagaModule } from '@lib/domains/user/application/sagas/user.saga.module';
 import { NecordConfigService } from './necord/necord.config.service';
 import { EVENT_HANDLERS } from './events/event-handlers';
 import { COMMAND_HANDLERS } from './commands/command-handlers';
 
 @Module({
   imports: [
+    CqrsModule,
     ConfigYamlModule,
     NecordModule.forRootAsync({
       useFactory: (configService: ConfigService) => ({
@@ -23,6 +28,9 @@ import { COMMAND_HANDLERS } from './commands/command-handlers';
       inject: [ConfigService],
       useClass: NecordConfigService,
     }),
+    UserCommandModule,
+    UserEventModule,
+    UserSagaModule,
   ],
   providers: [...EVENT_HANDLERS, ...COMMAND_HANDLERS],
 })

--- a/apps/bot/src/commands/command-handlers.ts
+++ b/apps/bot/src/commands/command-handlers.ts
@@ -1,4 +1,4 @@
-import { SendMessageHandler } from './communication/send-message.handler';
-import { PingHandler } from './info/ping.handler';
+import { PingSlashCommandHandler } from './info/ping.slash-command-handler';
+import { SendMessageSlashCommandHandler } from './communication/send-message.slash-command-handler';
 
-export const COMMAND_HANDLERS = [PingHandler, SendMessageHandler];
+export const COMMAND_HANDLERS = [PingSlashCommandHandler, SendMessageSlashCommandHandler];

--- a/apps/bot/src/commands/command-handlers.ts
+++ b/apps/bot/src/commands/command-handlers.ts
@@ -1,4 +1,9 @@
 import { PingSlashCommandHandler } from './info/ping.slash-command-handler';
 import { SendMessageSlashCommandHandler } from './communication/send-message.slash-command-handler';
+import { RegisterUserSlashCommandHandler } from './operation/register-user.slash-command-handler';
 
-export const COMMAND_HANDLERS = [PingSlashCommandHandler, SendMessageSlashCommandHandler];
+export const COMMAND_HANDLERS = [
+  PingSlashCommandHandler,
+  SendMessageSlashCommandHandler,
+  RegisterUserSlashCommandHandler,
+];

--- a/apps/bot/src/commands/command-handlers.ts
+++ b/apps/bot/src/commands/command-handlers.ts
@@ -1,3 +1,4 @@
+import { SendMessageHandler } from './communication/send-message.handler';
 import { PingHandler } from './info/ping.handler';
 
-export const COMMAND_HANDLERS = [PingHandler];
+export const COMMAND_HANDLERS = [PingHandler, SendMessageHandler];

--- a/apps/bot/src/commands/communication/send-message.handler.ts
+++ b/apps/bot/src/commands/communication/send-message.handler.ts
@@ -5,7 +5,7 @@ import { SendMessageRequest } from './send-message.request';
 
 @Injectable()
 export class SendMessageHandler {
-  @SlashCommand({ name: 'send-message', description: 'Send a message to the channel'})
+  @SlashCommand({ name: 'send-message', description: 'Send a message to the channel' })
   public async onSendMessage(
     @Context() [interaction]: SlashCommandContext,
     @Options() { message, channel }: SendMessageRequest,

--- a/apps/bot/src/commands/communication/send-message.handler.ts
+++ b/apps/bot/src/commands/communication/send-message.handler.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { Context, Options, SlashCommand, SlashCommandContext } from 'necord';
+import { ChannelType, TextBasedChannel } from 'discord.js';
+import { SendMessageRequest } from './send-message.request';
+
+@Injectable()
+export class SendMessageHandler {
+  @SlashCommand({ name: 'send-message', description: 'Send a message to the channel'})
+  public async onSendMessage(
+    @Context() [interaction]: SlashCommandContext,
+    @Options() { message, channel }: SendMessageRequest,
+  ) {
+    if (channel.type !== ChannelType.GuildText)
+      return interaction.reply({ content: `Invalid Channel Type: Text channel is required` });
+
+    const textChannel = channel as TextBasedChannel;
+    textChannel.send(message);
+    return interaction.reply({ content: `Sent a message: ${message} to ${channel.name}` });
+  }
+}

--- a/apps/bot/src/commands/communication/send-message.request.ts
+++ b/apps/bot/src/commands/communication/send-message.request.ts
@@ -1,0 +1,18 @@
+import { GuildChannel } from 'discord.js';
+import { ChannelOption, StringOption } from 'necord';
+
+export class SendMessageRequest {
+  @StringOption({
+    name: 'message',
+    description: 'your message',
+    required: true,
+  })
+  message: string;
+
+  @ChannelOption({
+    name: 'channel-id',
+    description: 'channel id',
+    required: true,
+  })
+  channel: GuildChannel;
+}

--- a/apps/bot/src/commands/communication/send-message.slash-command-handler.ts
+++ b/apps/bot/src/commands/communication/send-message.slash-command-handler.ts
@@ -4,7 +4,7 @@ import { ChannelType, TextBasedChannel } from 'discord.js';
 import { SendMessageRequest } from './send-message.request';
 
 @Injectable()
-export class SendMessageHandler {
+export class SendMessageSlashCommandHandler {
   @SlashCommand({ name: 'send-message', description: 'Send a message to the channel' })
   public async onSendMessage(
     @Context() [interaction]: SlashCommandContext,

--- a/apps/bot/src/commands/info/ping.slash-command-handler.ts
+++ b/apps/bot/src/commands/info/ping.slash-command-handler.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { Context, SlashCommand, SlashCommandContext } from 'necord';
 
 @Injectable()
-export class PingHandler {
+export class PingSlashCommandHandler {
   @SlashCommand({ name: 'ping', description: 'Ping-Pong Command' })
   public async onPing(@Context() [interaction]: SlashCommandContext) {
     return interaction.reply({ content: 'Pong!' });

--- a/apps/bot/src/commands/operation/register-user.request.ts
+++ b/apps/bot/src/commands/operation/register-user.request.ts
@@ -1,0 +1,11 @@
+import { User } from 'discord.js';
+import { UserOption } from 'necord';
+
+export class RegisterUserRequest {
+  @UserOption({
+    name: 'user',
+    description: 'User',
+    required: true,
+  })
+  user: User;
+}

--- a/apps/bot/src/commands/operation/register-user.slash-command-handler.ts
+++ b/apps/bot/src/commands/operation/register-user.slash-command-handler.ts
@@ -1,0 +1,34 @@
+import { Injectable, UseGuards } from '@nestjs/common';
+import { EventBus } from '@nestjs/cqrs';
+import { Context, Options, SlashCommand, SlashCommandContext } from 'necord';
+import { v4 as uuid4 } from 'uuid';
+import { UserRegisteredFromDiscordEvent } from '@lib/domains/user/application/events/user-registered-from-discord/user-registered-from-discord.event';
+import { GuildSlashCommandGuard } from '@app/bot/guards/guild.slash-command.guard';
+import { OwnerSlashCommandGuard } from '@app/bot/guards/owner.slash-command.guard';
+import { RegisterUserRequest } from './register-user.request';
+
+@UseGuards(GuildSlashCommandGuard)
+@UseGuards(OwnerSlashCommandGuard)
+@Injectable()
+export class RegisterUserSlashCommandHandler {
+  constructor(private readonly eventBus: EventBus) {}
+
+  @SlashCommand({ name: 'register-user', description: 'Register user in DB' })
+  public async onCreateUser(
+    @Context() [interaction]: SlashCommandContext,
+    @Options() { user }: RegisterUserRequest,
+  ) {
+    this.eventBus.publish(
+      new UserRegisteredFromDiscordEvent({
+        userId: uuid4(),
+        username: user.username,
+        socialAccountId: uuid4(),
+        provider: 'discord',
+        socialId: user.id,
+        guildId: interaction.guildId!,
+        memberId: uuid4(),
+        roleIds: [],
+      }),
+    );
+  }
+}

--- a/apps/bot/src/config/config.example.yaml
+++ b/apps/bot/src/config/config.example.yaml
@@ -1,6 +1,8 @@
 server:
   version:
   port:
+postgresql:
+  url:
 discord:
   bot:
     name:

--- a/apps/bot/src/guards/guild.slash-command.guard.ts
+++ b/apps/bot/src/guards/guild.slash-command.guard.ts
@@ -1,0 +1,13 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Interaction } from 'discord.js';
+
+@Injectable()
+export class GuildSlashCommandGuard implements CanActivate {
+  constructor(private configService: ConfigService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const [interaction]: [Interaction] = context.getArgByIndex(0);
+    return interaction.guildId === this.configService.get('discord.base-guild.id');
+  }
+}

--- a/apps/bot/src/guards/owner.slash-command.guard.ts
+++ b/apps/bot/src/guards/owner.slash-command.guard.ts
@@ -1,0 +1,13 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Interaction } from 'discord.js';
+
+@Injectable()
+export class OwnerSlashCommandGuard implements CanActivate {
+  constructor(private configService: ConfigService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const [interaction]: [Interaction] = context.getArgByIndex(0);
+    return interaction.user.id === this.configService.get('discord.bot.owner-id');
+  }
+}

--- a/apps/bot/src/necord/necord.config.service.ts
+++ b/apps/bot/src/necord/necord.config.service.ts
@@ -17,6 +17,7 @@ export class NecordConfigService {
         GatewayIntentBits.GuildMessageReactions,
         GatewayIntentBits.MessageContent,
       ],
+      development: [this.configService.get('discord.base-guild.id')!],
     };
   }
 }

--- a/libs/domains/src/user/application/events/user-registered-from-discord/user-registered-from-discord.event.ts
+++ b/libs/domains/src/user/application/events/user-registered-from-discord/user-registered-from-discord.event.ts
@@ -1,0 +1,30 @@
+import { UserRegisteredFromDisocrdInput } from './user-registered-from-discord.input';
+
+export class UserRegisteredFromDiscordEvent {
+  userId: string;
+
+  username: string;
+
+  socialAccountId: string;
+
+  provider: string;
+
+  socialId: string;
+
+  guildId: string;
+
+  memberId: string;
+
+  roleIds: string[];
+
+  constructor(input: UserRegisteredFromDisocrdInput) {
+    this.userId = input.userId;
+    this.username = input.username;
+    this.socialAccountId = input.socialAccountId;
+    this.provider = input.provider;
+    this.socialId = input.socialId;
+    this.guildId = input.guildId;
+    this.memberId = input.memberId;
+    this.roleIds = input.roleIds;
+  }
+}

--- a/libs/domains/src/user/application/events/user-registered-from-discord/user-registered-from-discord.handler.ts
+++ b/libs/domains/src/user/application/events/user-registered-from-discord/user-registered-from-discord.handler.ts
@@ -1,0 +1,12 @@
+import { EventsHandler, IEventHandler } from '@nestjs/cqrs';
+import { UserRegisteredFromDiscordEvent } from './user-registered-from-discord.event';
+
+@EventsHandler(UserRegisteredFromDiscordEvent)
+export class UserRegisteredFromDiscordHandler
+  implements IEventHandler<UserRegisteredFromDiscordEvent>
+{
+  handle(event: UserRegisteredFromDiscordEvent) {
+    // TODO: noti
+    console.log('User registered from discord');
+  }
+}

--- a/libs/domains/src/user/application/events/user-registered-from-discord/user-registered-from-discord.input.ts
+++ b/libs/domains/src/user/application/events/user-registered-from-discord/user-registered-from-discord.input.ts
@@ -1,0 +1,17 @@
+export class UserRegisteredFromDisocrdInput {
+  userId: string;
+
+  username: string;
+
+  socialAccountId: string;
+
+  provider: string;
+
+  socialId: string;
+
+  guildId: string;
+
+  memberId: string;
+
+  roleIds: string[];
+}

--- a/libs/domains/src/user/application/events/user.event.module.ts
+++ b/libs/domains/src/user/application/events/user.event.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { UserRegisteredFromDiscordHandler } from './user-registered-from-discord/user-registered-from-discord.handler';
+
+const eventHandlers = [UserRegisteredFromDiscordHandler];
+
+@Module({
+  providers: [...eventHandlers],
+  exports: [...eventHandlers],
+})
+export class UserEventModule {}

--- a/libs/domains/src/user/application/sagas/register-user/register-user.saga.ts
+++ b/libs/domains/src/user/application/sagas/register-user/register-user.saga.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { ICommand, Saga, ofType } from '@nestjs/cqrs';
+import { Observable, map } from 'rxjs';
+import { UserRegisteredFromDiscordEvent } from '../../events/user-registered-from-discord/user-registered-from-discord.event';
+import { CreateUserCommand } from '../../commands/create-user/create-user.command';
+
+@Injectable()
+export class RegisterUserSage {
+  @Saga()
+  registeredUser = (events$: Observable<any>): Observable<ICommand> =>
+    events$.pipe(
+      ofType(UserRegisteredFromDiscordEvent),
+      map(
+        (event) =>
+          new CreateUserCommand({
+            id: event.userId,
+            username: event.username,
+          }),
+        // TODO: create social-account, member
+      ),
+    );
+}

--- a/libs/domains/src/user/application/sagas/user.saga.module.ts
+++ b/libs/domains/src/user/application/sagas/user.saga.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { RegisterUserSage } from './register-user/register-user.saga';
+
+const sagas = [RegisterUserSage];
+
+@Module({
+  providers: [...sagas],
+  exports: [...sagas],
+})
+export class UserSagaModule {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2909,6 +2909,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/uuid@npm:^9.0.4":
+  version: 9.0.4
+  resolution: "@types/uuid@npm:9.0.4"
+  checksum: 356e2504456eaebbc43a5af5ca6c07d71f5ae5520b5767cb1c62cd0ec55475fc4ee3d16a2874f4a5fce78e40e8583025afd3a7d9ba41f82939de310665f53f0e
+  languageName: node
+  linkType: hard
+
 "@types/validator@npm:^13.7.10":
   version: 13.7.17
   resolution: "@types/validator@npm:13.7.17"
@@ -4009,6 +4016,7 @@ __metadata:
     "@nestjs/common": ^10.2.5
     "@nestjs/config": ^3.0.0
     "@nestjs/core": ^10.2.5
+    "@nestjs/cqrs": ^10.2.5
     "@nestjs/platform-fastify": ^10.1.2
     "@nestjs/schematics": ^10.0.1
     "@nestjs/swagger": ^7.1.6
@@ -4017,6 +4025,7 @@ __metadata:
     "@types/express": ^4.17.17
     "@types/js-yaml": ^4.0.5
     "@types/lodash": ^4.14.196
+    "@types/uuid": ^9.0.4
     axios: ^1.4.0
     cache-manager: ^5.2.3
     cache-manager-redis-store: ^3.0.1
@@ -4035,6 +4044,7 @@ __metadata:
     rxjs: ^7.8.1
     supertest: ^6.3.3
     typescript: ^5.1.6
+    uuid: ^9.0.1
   languageName: unknown
   linkType: soft
 
@@ -12034,6 +12044,15 @@ __metadata:
   bin:
     uuid: ./bin/uuid
   checksum: 58de2feed61c59060b40f8203c0e4ed7fd6f99d42534a499f1741218a1dd0c129f4aa1de797bcf822c8ea5da7e4137aa3673431a96dae729047f7aca7b27866f
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "uuid@npm:9.0.1"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 39931f6da74e307f51c0fb463dc2462807531dc80760a9bff1e35af4316131b4fc3203d16da60ae33f07fdca5b56f3f1dd662da0c99fea9aaeab2004780cc5f4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
discord 서버 `동물의 왕국`의 유저를 DB에 저장

## 어떻게 해결했나요?
1. discord user 저장 과정을 테스트 하기 위해 register-user slash command 생성
2. UserRegisteredFromDiscordEvent를 publish
3. RegisterUserSage에서 CreateUser command 생성

## Note
User 데이터 저장 후 Social Account, Member 데이터의 저장도 이루어져야 함

## 참고 자료
https://docs.nestjs.com/recipes/cqrs#sagas
https://microservices.io/patterns/data/saga.html
https://docs.nestjs.com/guards