### PR TITLE
feat: add join eventHandler in bot, add joinedUserCreated in saga

### DIFF
--- a/apps/bot/src/bot.module.ts
+++ b/apps/bot/src/bot.module.ts
@@ -5,8 +5,11 @@ import { NecordModule } from 'necord';
 import { ConfigService } from '@nestjs/config/dist';
 import { PrismaModule } from '@lib/shared/prisma/prisma.module';
 import { USER_PROVIDERS } from '@lib/domains/user/user.providers';
+import { SOCIAL_ACCOUNT_PROVIDERS } from '@lib/domains/social-account/social-account.providers';
+import { MEMBER_PROVIDERS } from '@lib/domains/member/member.providers';
 import { NecordConfigService } from './necord/necord.config.service';
 import { COMMAND_HANDLERS } from './commands/command-handlers';
+import { EVENT_HANDLERS } from './events/event-handlers';
 
 @Module({
   imports: [
@@ -28,6 +31,12 @@ import { COMMAND_HANDLERS } from './commands/command-handlers';
       useClass: NecordConfigService,
     }),
   ],
-  providers: [...USER_PROVIDERS, ...COMMAND_HANDLERS],
+  providers: [
+    ...USER_PROVIDERS,
+    ...SOCIAL_ACCOUNT_PROVIDERS,
+    ...MEMBER_PROVIDERS,
+    ...COMMAND_HANDLERS,
+    ...EVENT_HANDLERS,
+  ],
 })
 export class BotModule {}

--- a/apps/bot/src/commands/operation/register-user.slash-command-handler.ts
+++ b/apps/bot/src/commands/operation/register-user.slash-command-handler.ts
@@ -2,6 +2,7 @@ import { Injectable, UseGuards } from '@nestjs/common';
 import { EventBus } from '@nestjs/cqrs';
 import { Context, Options, SlashCommand, SlashCommandContext } from 'necord';
 import { v4 as uuid4 } from 'uuid';
+import { ConfigService } from '@nestjs/config';
 import { UserjoinedEvent } from '@lib/domains/user/application/events/user-joined/user-joined.event';
 import { GuildSlashCommandGuard } from '@app/bot/guards/guild.slash-command.guard';
 import { OwnerSlashCommandGuard } from '@app/bot/guards/owner.slash-command.guard';
@@ -11,7 +12,10 @@ import { RegisterUserRequest } from './register-user.request';
 @UseGuards(OwnerSlashCommandGuard)
 @Injectable()
 export class RegisterUserSlashCommandHandler {
-  constructor(private readonly eventBus: EventBus) {}
+  constructor(
+    private readonly eventBus: EventBus,
+    private readonly configService: ConfigService,
+  ) {}
 
   @SlashCommand({ name: 'register-user', description: 'Register user in DB' })
   public async onCreateUser(
@@ -25,7 +29,7 @@ export class RegisterUserSlashCommandHandler {
         socialAccountId: uuid4(),
         provider: 'discord',
         socialId: user.id,
-        guildId: interaction.guildId!,
+        guildId: this.configService.get('discord.guild.id')!,
         memberId: uuid4(),
         roleIds: [],
       }),

--- a/apps/bot/src/config/config.example.yaml
+++ b/apps/bot/src/config/config.example.yaml
@@ -9,7 +9,9 @@ discord:
     client-id:
     token:
     owner-id:
-  base-guild:
+  server:
+    id:
+  guild:
     id:
 document:
   title:

--- a/apps/bot/src/events/event-handlers.ts
+++ b/apps/bot/src/events/event-handlers.ts
@@ -1,4 +1,5 @@
+import { JoinHandler } from './member/join.handler';
 import { ReadyHandler } from './system/ready.handler';
 import { WarnHandler } from './system/warn.handler';
 
-export const EVENT_HANDLERS = [ReadyHandler, WarnHandler];
+export const EVENT_HANDLERS = [ReadyHandler, WarnHandler, JoinHandler];

--- a/apps/bot/src/events/member/join.handler.ts
+++ b/apps/bot/src/events/member/join.handler.ts
@@ -1,10 +1,12 @@
+import { GuildMemberEventGuard } from '@app/bot/guards/guild-member.event.guard';
 import { UserjoinedEvent } from '@lib/domains/user/application/events/user-joined/user-joined.event';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, UseGuards } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { EventBus } from '@nestjs/cqrs';
 import { Context, ContextOf, On } from 'necord';
 import { v4 as uuid4 } from 'uuid';
 
+@UseGuards(GuildMemberEventGuard)
 @Injectable()
 export class JoinHandler {
   private readonly logger = new Logger(JoinHandler.name);

--- a/apps/bot/src/events/member/join.handler.ts
+++ b/apps/bot/src/events/member/join.handler.ts
@@ -1,0 +1,33 @@
+import { UserjoinedEvent } from '@lib/domains/user/application/events/user-joined/user-joined.event';
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { EventBus } from '@nestjs/cqrs';
+import { Context, ContextOf, On } from 'necord';
+import { v4 as uuid4 } from 'uuid';
+
+@Injectable()
+export class JoinHandler {
+  private readonly logger = new Logger(JoinHandler.name);
+
+  constructor(
+    private readonly eventBus: EventBus,
+    private readonly configService: ConfigService,
+  ) {}
+
+  @On('guildMemberAdd')
+  public async onceReady(@Context() [member]: ContextOf<'guildMemberAdd'>) {
+    this.eventBus.publish(
+      new UserjoinedEvent({
+        userId: uuid4(),
+        username: member.user.username,
+        socialAccountId: uuid4(),
+        provider: 'discord',
+        socialId: member.user.id,
+        guildId: this.configService.get('discord.guild.id')!,
+        memberId: uuid4(),
+        roleIds: [],
+      }),
+    );
+    this.logger.log(`${member.user.username}<@${member.user.id}> joined discord server`);
+  }
+}

--- a/apps/bot/src/guards/guild-member.event.guard.ts
+++ b/apps/bot/src/guards/guild-member.event.guard.ts
@@ -1,0 +1,13 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { GuildMember } from 'discord.js';
+
+@Injectable()
+export class GuildMemberEventGuard implements CanActivate {
+  constructor(private configService: ConfigService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const [member]: [GuildMember] = context.getArgByIndex(0);
+    return member.guild.id === this.configService.get('discord.server.id');
+  }
+}

--- a/apps/bot/src/guards/guild.slash-command.guard.ts
+++ b/apps/bot/src/guards/guild.slash-command.guard.ts
@@ -8,6 +8,6 @@ export class GuildSlashCommandGuard implements CanActivate {
 
   canActivate(context: ExecutionContext): boolean {
     const [interaction]: [Interaction] = context.getArgByIndex(0);
-    return interaction.guildId === this.configService.get('discord.base-guild.id');
+    return interaction.guildId === this.configService.get('discord.server.id');
   }
 }

--- a/apps/bot/src/necord/necord.config.service.ts
+++ b/apps/bot/src/necord/necord.config.service.ts
@@ -17,7 +17,7 @@ export class NecordConfigService {
         GatewayIntentBits.GuildMessageReactions,
         GatewayIntentBits.MessageContent,
       ],
-      development: [this.configService.get('discord.base-guild.id')!],
+      development: [this.configService.get('discord.server.id')!],
     };
   }
 }

--- a/libs/domains/src/user/application/commands/create-joined-user/create-joined-user.handler.ts
+++ b/libs/domains/src/user/application/commands/create-joined-user/create-joined-user.handler.ts
@@ -21,12 +21,26 @@ export class CreateJoinedUserHandler implements ICommandHandler<CreateJoinedUser
     );
 
     if (user) return;
-
-    const newUser = new UserEntity({
-      id: command.userId,
-      username: command.username,
-    });
-
+    const newUser = this.publisher.mergeObjectContext(
+      new UserEntity({
+        id: command.userId,
+        username: command.username,
+      }),
+    );
     await this.userSavePort.create(newUser);
+
+    newUser.createdJoinedUser(
+      _.pick(
+        command,
+        'userId',
+        'username',
+        'socialAccountId',
+        'provider',
+        'socialId',
+        'guildId',
+        'memberId',
+        'roleIds',
+      ),
+    );
   }
 }

--- a/libs/domains/src/user/application/events/joined-user-created/joined-user-created.event.ts
+++ b/libs/domains/src/user/application/events/joined-user-created/joined-user-created.event.ts
@@ -1,0 +1,28 @@
+import { IEvent } from '@nestjs/cqrs/dist';
+import { JoinedUserCreatedInput } from './joined-user-created.input';
+
+export class JoinedUserCreatedEvent implements IEvent {
+  userId: string;
+
+  socialAccountId: string;
+
+  provider: string;
+
+  socialId: string;
+
+  guildId: string;
+
+  memberId: string;
+
+  roleIds: string[];
+
+  constructor(input: JoinedUserCreatedInput) {
+    this.userId = input.userId;
+    this.socialAccountId = input.socialAccountId;
+    this.provider = input.provider;
+    this.socialId = input.socialId;
+    this.guildId = input.guildId;
+    this.memberId = input.memberId;
+    this.roleIds = input.roleIds;
+  }
+}

--- a/libs/domains/src/user/application/events/joined-user-created/joined-user-created.handler.ts
+++ b/libs/domains/src/user/application/events/joined-user-created/joined-user-created.handler.ts
@@ -1,0 +1,10 @@
+import { EventsHandler, IEventHandler } from '@nestjs/cqrs';
+import { JoinedUserCreatedEvent } from './joined-user-created.event';
+
+@EventsHandler(JoinedUserCreatedEvent)
+export class JoinedUserCreatedHandler implements IEventHandler<JoinedUserCreatedEvent> {
+  handle(event: JoinedUserCreatedEvent) {
+    // TODO: noti
+    console.log('Joined User Created');
+  }
+}

--- a/libs/domains/src/user/application/events/joined-user-created/joined-user-created.input.ts
+++ b/libs/domains/src/user/application/events/joined-user-created/joined-user-created.input.ts
@@ -1,0 +1,15 @@
+export class JoinedUserCreatedInput {
+  userId: string;
+
+  socialAccountId: string;
+
+  provider: string;
+
+  socialId: string;
+
+  guildId: string;
+
+  memberId: string;
+
+  roleIds: string[];
+}

--- a/libs/domains/src/user/application/events/user.event.providers.ts
+++ b/libs/domains/src/user/application/events/user.event.providers.ts
@@ -1,3 +1,4 @@
 import { UserjoinedHandler } from './user-joined/user-joined.handler';
+import { JoinedUserCreatedHandler } from './joined-user-created/joined-user-created.handler';
 
-export const USER_EVENT_PROVIDERS = [UserjoinedHandler];
+export const USER_EVENT_PROVIDERS = [UserjoinedHandler, JoinedUserCreatedHandler];

--- a/libs/domains/src/user/application/sagas/join-user/join-user.saga.ts
+++ b/libs/domains/src/user/application/sagas/join-user/join-user.saga.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { ICommand, Saga, ofType } from '@nestjs/cqrs';
-import { Observable, map } from 'rxjs';
+import { Observable, map, mergeMap, of } from 'rxjs';
 import { CreateSocialAccountCommand } from '@lib/domains/social-account/application/commands/create-social-account/create-social-account.command';
+import { CreateMemberCommand } from '@lib/domains/member/application/commands/create-member/create-member.command';
 import { CreateJoinedUserCommand } from '../../commands/create-joined-user/create-joined-user.command';
 import { UserjoinedEvent } from '../../events/user-joined/user-joined.event';
 import { JoinedUserCreatedEvent } from '../../events/joined-user-created/joined-user-created.event';
@@ -19,14 +20,20 @@ export class JoinUserSaga {
   joinedUserCreated = (events$: Observable<any>): Observable<ICommand> =>
     events$.pipe(
       ofType(JoinedUserCreatedEvent),
-      map(
-        (event) =>
+      mergeMap((event) =>
+        of(
           new CreateSocialAccountCommand({
             id: event.socialAccountId,
             provider: event.provider,
             socialId: event.socialId,
             userId: event.userId,
           }),
+          new CreateMemberCommand({
+            id: event.memberId,
+            userId: event.userId,
+            guildId: event.guildId,
+          }),
+        ),
       ),
     );
 }

--- a/libs/domains/src/user/domain/user.entity.ts
+++ b/libs/domains/src/user/domain/user.entity.ts
@@ -1,6 +1,8 @@
 import { MemberEntity } from '@lib/domains/member/domain/member.entity';
 import { SocialAccountEntity } from '@lib/domains/social-account/domain/social-account.entity';
 import { AggregateRoot } from '@nestjs/cqrs';
+import { JoinedUserCreatedInput } from '../application/events/joined-user-created/joined-user-created.input';
+import { JoinedUserCreatedEvent } from '../application/events/joined-user-created/joined-user-created.event';
 
 export class UserEntity extends AggregateRoot {
   id: string;
@@ -26,5 +28,10 @@ export class UserEntity extends AggregateRoot {
   constructor(partial: Partial<UserEntity>) {
     super();
     Object.assign(this, partial);
+  }
+
+  createdJoinedUser(input: JoinedUserCreatedInput) {
+    this.apply(new JoinedUserCreatedEvent(input));
+    this.commit();
   }
 }


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
디스코드 서버에 입장하는 멤버의 user, social-account, member 데이터 저장하기

## 어떻게 해결했나요?
1. bot의 event handler에서 'guildMemberAdd' event 감지
2. UserjoinedEvent publish
3. JoinUserSaga에서 CreateJoinedUserCommand publish
4. user가 존재하는 지 체크 후, 없을 경우 생성
5. JoinedUserCreatedEvent publish
4. JoinUserSaga에서 CreateSocialAccountCommand, CreateMemberCommand publish