### PR TITLE
feat: add findGuildPreviews

### DIFF
--- a/apps/api/src/app/guild/guild.resolver.ts
+++ b/apps/api/src/app/guild/guild.resolver.ts
@@ -12,6 +12,8 @@ import { PaginatedGuildsResponse } from '@lib/domains/guild/application/queries/
 import { FindGuildsArgs } from '@lib/domains/guild/application/queries/find-guilds/find-guilds.args';
 import { FindGuildQuery } from '@lib/domains/guild/application/queries/find-guild/find-guild.query';
 import { FindGuildArgs } from '@lib/domains/guild/application/queries/find-guild/find-guild.args';
+import { GuildPreviewResponse } from '@lib/domains/guild/application/dtos/guild-preview.response';
+import { FindGuildPreviewsQuery } from '@lib/domains/guild/application/queries/find-guild-previews/find-guild-previews.query';
 
 @Resolver()
 export class GuildResolver {
@@ -35,6 +37,12 @@ export class GuildResolver {
   @Query(() => PaginatedGuildsResponse)
   async findGuilds(@Args() findGuildsArgs: FindGuildsArgs): Promise<PaginatedGuildsResponse> {
     const query = new FindGuildsQuery(findGuildsArgs);
+    return this.queryBus.execute(query);
+  }
+
+  @Query(() => [GuildPreviewResponse])
+  async findGuildPreviews(): Promise<GuildPreviewResponse[]> {
+    const query = new FindGuildPreviewsQuery();
     return this.queryBus.execute(query);
   }
 

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -244,6 +244,17 @@ input DisconnectRolesInput {
   roleIds: [ID!]!
 }
 
+type GuildPreviewResponse {
+  demands: [DemandResponse!]!
+  description: String
+  icon: String
+  id: ID!
+  name: String!
+  offers: [OfferResponse!]!
+  position: Int
+  slug: String
+}
+
 type GuildResponse {
   description: String
   icon: String
@@ -340,6 +351,7 @@ type OfferResponse {
   slug: String
   source: String!
   status: String!
+  thumbnail: UserImageResponse
   updatedAt: DateTime!
 }
 
@@ -407,6 +419,7 @@ type Query {
   findDemands(cursor: ID, productCategoryId: ID!, skip: Int! = 1, take: Int!): PaginatedDemandsResponse!
   findGuild(slug: String): GuildResponse
   findGuildById(id: ID!): GuildResponse
+  findGuildPreviews: [GuildPreviewResponse!]!
   findGuilds(cursor: ID, skip: Int! = 1, take: Int!): PaginatedGuildsResponse!
   findMemberByUserAndGuild(guildId: ID!, userId: ID!): MemberWithRolesResponse
   findMyUserById(id: ID!): MyUserResponse
@@ -482,6 +495,7 @@ type SwapResponse {
   slug: String
   source: String!
   status: String!
+  thumbnail: UserImageResponse
   updatedAt: DateTime!
 }
 

--- a/libs/domains/src/guild/application/dtos/guild-preview.response.ts
+++ b/libs/domains/src/guild/application/dtos/guild-preview.response.ts
@@ -1,0 +1,37 @@
+import { Field, ID, Int, ObjectType } from '@nestjs/graphql';
+import { IsOptional } from 'class-validator';
+import { OfferResponse } from '@lib/domains/offer/application/dtos/offer.response';
+import { DemandResponse } from '@lib/domains/demand/application/dtos/demand.response';
+
+@ObjectType()
+export class GuildPreviewResponse {
+  @Field(() => ID)
+  id: string;
+
+  @Field()
+  name: string;
+
+  @Field(() => String, { nullable: true })
+  slug: string | null;
+
+  @IsOptional()
+  @Field(() => String, { nullable: true })
+  description: string | null;
+
+  @IsOptional()
+  @Field(() => String, { nullable: true })
+  icon: string | null;
+
+  @Field(() => Int, { nullable: true })
+  position: number;
+
+  @Field(() => [OfferResponse])
+  offers: OfferResponse[];
+
+  @Field(() => [DemandResponse])
+  demands: DemandResponse[];
+
+  constructor(partial: Partial<GuildPreviewResponse>) {
+    Object.assign(this, partial);
+  }
+}

--- a/libs/domains/src/guild/application/queries/find-guild-previews/find-guild-previews.handler.ts
+++ b/libs/domains/src/guild/application/queries/find-guild-previews/find-guild-previews.handler.ts
@@ -49,7 +49,7 @@ export class FindGuildPreviewsHandler extends PrismaQueryHandler<
     const guildPreviews = guilds.map(async (guild) => {
       const offerWithImagePromises = guild.offers.map(async (offer) => ({
         ...offer,
-        image: await this.prismaService.userImage.findFirst({
+        thumbnail: await this.prismaService.userImage.findFirst({
           where: {
             type: 'offer',
             refId: offer.id,

--- a/libs/domains/src/guild/application/queries/find-guild-previews/find-guild-previews.handler.ts
+++ b/libs/domains/src/guild/application/queries/find-guild-previews/find-guild-previews.handler.ts
@@ -1,0 +1,70 @@
+import { QueryHandler } from '@nestjs/cqrs';
+import { PrismaQueryHandler } from '@lib/shared/cqrs/queries/handlers/prisma-query.handler';
+import { FindGuildPreviewsQuery } from './find-guild-previews.query';
+import { GuildPreviewResponse } from '../../dtos/guild-preview.response';
+
+@QueryHandler(FindGuildPreviewsQuery)
+export class FindGuildPreviewsHandler extends PrismaQueryHandler<
+  FindGuildPreviewsQuery,
+  GuildPreviewResponse
+> {
+  constructor() {
+    super(GuildPreviewResponse);
+  }
+
+  async execute(query: FindGuildPreviewsQuery): Promise<GuildPreviewResponse[]> {
+    const guilds = await this.prismaService.guild.findMany({
+      orderBy: {
+        position: 'asc',
+      },
+      include: {
+        offers: {
+          include: {
+            seller: {
+              select: {
+                username: true,
+              },
+            },
+          },
+          orderBy: {
+            createdAt: 'desc',
+          },
+          take: 3,
+        },
+        demands: {
+          include: {
+            buyer: {
+              select: {
+                username: true,
+              },
+            },
+          },
+          orderBy: {
+            createdAt: 'desc',
+          },
+          take: 5,
+        },
+      },
+    });
+    const guildPreviews = guilds.map(async (guild) => {
+      const offersWithImage = guild.offers.map(async (offer) => ({
+        ...offer,
+        image: await this.prismaService.userImage.findFirst({
+          where: {
+            type: 'offer',
+            refId: offer.id,
+            tracked: true,
+          },
+          orderBy: {
+            createdAt: 'desc',
+          },
+        }),
+      }));
+      return {
+        ...guild,
+        offers: await Promise.all(offersWithImage),
+      };
+    });
+    return this.parseResponses(guildPreviews);
+  }
+}

--- a/libs/domains/src/guild/application/queries/find-guild-previews/find-guild-previews.handler.ts
+++ b/libs/domains/src/guild/application/queries/find-guild-previews/find-guild-previews.handler.ts
@@ -47,7 +47,7 @@ export class FindGuildPreviewsHandler extends PrismaQueryHandler<
       },
     });
     const guildPreviews = guilds.map(async (guild) => {
-      const offersWithImage = guild.offers.map(async (offer) => ({
+      const offerWithImagePromises = guild.offers.map(async (offer) => ({
         ...offer,
         image: await this.prismaService.userImage.findFirst({
           where: {
@@ -62,7 +62,7 @@ export class FindGuildPreviewsHandler extends PrismaQueryHandler<
       }));
       return {
         ...guild,
-        offers: await Promise.all(offersWithImage),
+        offers: await Promise.all(offerWithImagePromises),
       };
     });
     return this.parseResponses(guildPreviews);

--- a/libs/domains/src/guild/application/queries/find-guild-previews/find-guild-previews.handler.ts
+++ b/libs/domains/src/guild/application/queries/find-guild-previews/find-guild-previews.handler.ts
@@ -42,7 +42,7 @@ export class FindGuildPreviewsHandler extends PrismaQueryHandler<
           orderBy: {
             createdAt: 'desc',
           },
-          take: 5,
+          take: 3,
         },
       },
     });

--- a/libs/domains/src/guild/application/queries/find-guild-previews/find-guild-previews.query.ts
+++ b/libs/domains/src/guild/application/queries/find-guild-previews/find-guild-previews.query.ts
@@ -1,0 +1,3 @@
+import { IQuery } from '@nestjs/cqrs';
+
+export class FindGuildPreviewsQuery implements IQuery {}

--- a/libs/domains/src/guild/application/queries/guild.query.providers.ts
+++ b/libs/domains/src/guild/application/queries/guild.query.providers.ts
@@ -1,5 +1,11 @@
 import { FindGuildByIdHandler } from './find-guild-by-id/find-guild-by-id.handler';
 import { FindGuildHandler } from './find-guild/find-guild.handler';
 import { FindGuildsHandler } from './find-guilds/find-guilds.handler';
+import { FindGuildPreviewsHandler } from './find-guild-previews/find-guild-previews.handler';
 
-export const GUILD_QUERY_PROVIDERS = [FindGuildByIdHandler, FindGuildHandler, FindGuildsHandler];
+export const GUILD_QUERY_PROVIDERS = [
+  FindGuildByIdHandler,
+  FindGuildHandler,
+  FindGuildsHandler,
+  FindGuildPreviewsHandler,
+];

--- a/libs/domains/src/offer/application/dtos/offer.response.ts
+++ b/libs/domains/src/offer/application/dtos/offer.response.ts
@@ -40,6 +40,9 @@ export class OfferResponse {
   @Field(() => [UserImageResponse])
   images: UserImageResponse[];
 
+  @Field(() => UserImageResponse, { nullable: true })
+  thumbnail: UserImageResponse | null;
+
   @Field()
   guildId: string;
 

--- a/libs/domains/src/offer/application/queries/find-offers/find-offers.handler.ts
+++ b/libs/domains/src/offer/application/queries/find-offers/find-offers.handler.ts
@@ -42,16 +42,23 @@ export class FindOffersHandler extends PrismaQueryHandler<FindOffersQuery, Offer
         },
       },
     });
-    const offerWithImagesPromises = offers.map(async (offer) => ({
-      ...offer,
-      images: await this.prismaService.userImage.findMany({
+    const offerWithImagesPromises = offers.map(async (offer) => {
+      const images = await this.prismaService.userImage.findMany({
         where: {
           type: 'offer',
           refId: offer.id,
           tracked: true,
         },
-      }),
-    }));
+        orderBy: {
+          createdAt: 'asc',
+        },
+      });
+      return {
+        ...offer,
+        images,
+        thumbnail: images[0],
+      };
+    });
     return paginate<OfferResponse>(
       this.parseResponses(await Promise.all(offerWithImagesPromises)),
       'id',

--- a/libs/domains/src/swap/application/dtos/swap.response.ts
+++ b/libs/domains/src/swap/application/dtos/swap.response.ts
@@ -43,6 +43,9 @@ export class SwapResponse {
   @Field(() => [UserImageResponse])
   images: UserImageResponse[];
 
+  @Field(() => UserImageResponse, { nullable: true })
+  thumbnail: UserImageResponse | null;
+
   @Field()
   guildId: string;
 

--- a/libs/domains/src/swap/application/queries/find-swaps/find-swaps.handler.ts
+++ b/libs/domains/src/swap/application/queries/find-swaps/find-swaps.handler.ts
@@ -42,16 +42,23 @@ export class FindSwapsHandler extends PrismaQueryHandler<FindSwapsQuery, SwapRes
         },
       },
     });
-    const swapWithImagesPromises = swaps.map(async (swap) => ({
-      ...swap,
-      images: await this.prismaService.userImage.findMany({
+    const swapWithImagesPromises = swaps.map(async (swap) => {
+      const images = await this.prismaService.userImage.findMany({
         where: {
           type: 'swap',
           refId: swap.id,
           tracked: true,
         },
-      }),
-    }));
+        orderBy: {
+          createdAt: 'asc',
+        },
+      });
+      return {
+        ...swap,
+        images,
+        thumbnail: images[0],
+      };
+    });
     return paginate<SwapResponse>(
       this.parseResponses(await Promise.all(swapWithImagesPromises)),
       'id',


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
home에서 guild 정보 및 요약 정보를 간략하게 보여주기

## 어떻게 해결했나요?
findGuildPreviews query handler 추가
guild preview에는 최신 판매글, 구매글 3개씩을 포함