### PR TITLE
feat: add distinct in findMany, use Throttler Guard

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,6 +18,7 @@
     "@nestjs/passport": "^10.0.3",
     "@nestjs/platform-express": "^10.3.2",
     "@nestjs/swagger": "^7.1.6",
+    "@nestjs/throttler": "^5.1.2",
     "@types/cookie-parser": "^1.4.6",
     "axios": "^1.4.0",
     "cache-manager": "^5.2.3",

--- a/apps/api/src/api.module.ts
+++ b/apps/api/src/api.module.ts
@@ -2,6 +2,7 @@ import { join } from 'path';
 import { Module } from '@nestjs/common';
 import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
 import { GraphQLModule } from '@nestjs/graphql';
+import { ThrottlerModule } from '@nestjs/throttler';
 import { ConfigYamlModule } from '@app/api/config/config.module';
 import { DateTimeResolver, DateTimeTypeDefinition } from 'graphql-scalars';
 import { GraphQLJSON } from 'graphql-type-json';
@@ -36,6 +37,12 @@ import { CommonModule } from './app/common/common.module';
       },
       context: (context: any) => context,
     }),
+    ThrottlerModule.forRoot([
+      {
+        ttl: 60000, // milliseconds
+        limit: 100,
+      },
+    ]),
     AuthModule,
     CommonModule,
     UserModule,

--- a/apps/api/src/app/auction/auction.resolver.ts
+++ b/apps/api/src/app/auction/auction.resolver.ts
@@ -15,9 +15,9 @@ import { PaginatedAuctionsResponse } from '@lib/domains/auction/application/quer
 import { FindAuctionsArgs } from '@lib/domains/auction/application/queries/find-auctions/find-auctions.args';
 import { FindAuctionsQuery } from '@lib/domains/auction/application/queries/find-auctions/find-auctions.query';
 import { UseGuards } from '@nestjs/common';
-import { GqlThrottlerGuard } from '../throttler/gql-throttler.guard';
+import { GqlThrottlerBehindProxyGuard } from '../throttler/gql-throttler-behind-proxy.guard';
 
-@UseGuards(GqlThrottlerGuard)
+@UseGuards(GqlThrottlerBehindProxyGuard)
 @Resolver()
 export class AuctionResolver {
   constructor(

--- a/apps/api/src/app/auction/auction.resolver.ts
+++ b/apps/api/src/app/auction/auction.resolver.ts
@@ -14,7 +14,10 @@ import { CancelBidCommand } from '@lib/domains/auction/application/commands/canc
 import { PaginatedAuctionsResponse } from '@lib/domains/auction/application/queries/find-auctions/paginated-auctions.response';
 import { FindAuctionsArgs } from '@lib/domains/auction/application/queries/find-auctions/find-auctions.args';
 import { FindAuctionsQuery } from '@lib/domains/auction/application/queries/find-auctions/find-auctions.query';
+import { UseGuards } from '@nestjs/common';
+import { GqlThrottlerGuard } from '../throttler/gql-throttler.guard';
 
+@UseGuards(GqlThrottlerGuard)
 @Resolver()
 export class AuctionResolver {
   constructor(

--- a/apps/api/src/app/auth/auth.controller.ts
+++ b/apps/api/src/app/auth/auth.controller.ts
@@ -9,7 +9,9 @@ import { AuthGuard } from '@nestjs/passport';
 import { JwtService } from '@lib/shared/jwt/jwt.service';
 import { UpdateSocialAccountCommand } from '@lib/domains/social-account/application/commands/update-social-account/update-social-account.command';
 import { ConfigService } from '@nestjs/config';
+import { ThrottlerGuard } from '@nestjs/throttler';
 
+@UseGuards(ThrottlerGuard)
 @Controller('api/auth')
 export class AuthController {
   constructor(

--- a/apps/api/src/app/auth/auth.controller.ts
+++ b/apps/api/src/app/auth/auth.controller.ts
@@ -9,9 +9,9 @@ import { AuthGuard } from '@nestjs/passport';
 import { JwtService } from '@lib/shared/jwt/jwt.service';
 import { UpdateSocialAccountCommand } from '@lib/domains/social-account/application/commands/update-social-account/update-social-account.command';
 import { ConfigService } from '@nestjs/config';
-import { ThrottlerGuard } from '@nestjs/throttler';
+import { ThrottlerBehindProxyGuard } from '../throttler/throttler-behind-proxy.guard';
 
-@UseGuards(ThrottlerGuard)
+@UseGuards(ThrottlerBehindProxyGuard)
 @Controller('api/auth')
 export class AuthController {
   constructor(

--- a/apps/api/src/app/auth/auth.resolver.ts
+++ b/apps/api/src/app/auth/auth.resolver.ts
@@ -8,7 +8,9 @@ import { UpdateSocialAccountCommand } from '@lib/domains/social-account/applicat
 import { SocialUserResponse } from '@lib/domains/social-account/application/dtos/social-user.response';
 import { JwtRefreshAuthGuard } from './jwt/jwt-refresh-auth.guard';
 import { JwtResponse } from './jwt/jwt.response';
+import { GqlThrottlerGuard } from '../throttler/gql-throttler.guard';
 
+@UseGuards(GqlThrottlerGuard)
 @Resolver()
 export class AuthResolver {
   constructor(

--- a/apps/api/src/app/auth/auth.resolver.ts
+++ b/apps/api/src/app/auth/auth.resolver.ts
@@ -8,9 +8,9 @@ import { UpdateSocialAccountCommand } from '@lib/domains/social-account/applicat
 import { SocialUserResponse } from '@lib/domains/social-account/application/dtos/social-user.response';
 import { JwtRefreshAuthGuard } from './jwt/jwt-refresh-auth.guard';
 import { JwtResponse } from './jwt/jwt.response';
-import { GqlThrottlerGuard } from '../throttler/gql-throttler.guard';
+import { GqlThrottlerBehindProxyGuard } from '../throttler/gql-throttler-behind-proxy.guard';
 
-@UseGuards(GqlThrottlerGuard)
+@UseGuards(GqlThrottlerBehindProxyGuard)
 @Resolver()
 export class AuthResolver {
   constructor(

--- a/apps/api/src/app/common/common.controller.ts
+++ b/apps/api/src/app/common/common.controller.ts
@@ -1,8 +1,8 @@
 import { Controller, Get, HttpStatus, Res, UseGuards } from '@nestjs/common';
-import { ThrottlerGuard } from '@nestjs/throttler';
 import { Response } from 'express';
+import { ThrottlerBehindProxyGuard } from '../throttler/throttler-behind-proxy.guard';
 
-@UseGuards(ThrottlerGuard)
+@UseGuards(ThrottlerBehindProxyGuard)
 @Controller()
 export class CommonController {
   @Get('favicon.ico')

--- a/apps/api/src/app/common/common.controller.ts
+++ b/apps/api/src/app/common/common.controller.ts
@@ -1,6 +1,8 @@
-import { Controller, Get, HttpStatus, Res } from '@nestjs/common';
+import { Controller, Get, HttpStatus, Res, UseGuards } from '@nestjs/common';
+import { ThrottlerGuard } from '@nestjs/throttler';
 import { Response } from 'express';
 
+@UseGuards(ThrottlerGuard)
 @Controller()
 export class CommonController {
   @Get('favicon.ico')

--- a/apps/api/src/app/demand/demand.resolver.ts
+++ b/apps/api/src/app/demand/demand.resolver.ts
@@ -11,7 +11,10 @@ import { FindDemandPreviewsQuery } from '@lib/domains/demand/application/queries
 import { PaginatedDemandPreviewsResponse } from '@lib/domains/demand/application/queries/find-demand-previews/paginated-demand-previews.response';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { Args, ID, Mutation, Query, Resolver } from '@nestjs/graphql';
+import { UseGuards } from '@nestjs/common';
+import { GqlThrottlerGuard } from '../throttler/gql-throttler.guard';
 
+@UseGuards(GqlThrottlerGuard)
 @Resolver()
 export class DemandResolver {
   constructor(

--- a/apps/api/src/app/demand/demand.resolver.ts
+++ b/apps/api/src/app/demand/demand.resolver.ts
@@ -12,9 +12,9 @@ import { PaginatedDemandPreviewsResponse } from '@lib/domains/demand/application
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { Args, ID, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { UseGuards } from '@nestjs/common';
-import { GqlThrottlerGuard } from '../throttler/gql-throttler.guard';
+import { GqlThrottlerBehindProxyGuard } from '../throttler/gql-throttler-behind-proxy.guard';
 
-@UseGuards(GqlThrottlerGuard)
+@UseGuards(GqlThrottlerBehindProxyGuard)
 @Resolver()
 export class DemandResolver {
   constructor(

--- a/apps/api/src/app/discord-message/discord-message.resolver.ts
+++ b/apps/api/src/app/discord-message/discord-message.resolver.ts
@@ -3,9 +3,9 @@ import { CreateDiscordMessageInput } from '@lib/domains/discord-message/applicat
 import { UseGuards } from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { Args, Mutation, Resolver } from '@nestjs/graphql';
-import { GqlThrottlerGuard } from '../throttler/gql-throttler.guard';
+import { GqlThrottlerBehindProxyGuard } from '../throttler/gql-throttler-behind-proxy.guard';
 
-@UseGuards(GqlThrottlerGuard)
+@UseGuards(GqlThrottlerBehindProxyGuard)
 @Resolver()
 export class DiscordMessageResolver {
   constructor(

--- a/apps/api/src/app/discord-message/discord-message.resolver.ts
+++ b/apps/api/src/app/discord-message/discord-message.resolver.ts
@@ -1,8 +1,11 @@
 import { CreateDiscordMessageCommand } from '@lib/domains/discord-message/application/commands/create-discord-message/create-discord-message.command';
 import { CreateDiscordMessageInput } from '@lib/domains/discord-message/application/commands/create-discord-message/create-discord-message.input';
+import { UseGuards } from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { Args, Mutation, Resolver } from '@nestjs/graphql';
+import { GqlThrottlerGuard } from '../throttler/gql-throttler.guard';
 
+@UseGuards(GqlThrottlerGuard)
 @Resolver()
 export class DiscordMessageResolver {
   constructor(

--- a/apps/api/src/app/group/group.resolver.ts
+++ b/apps/api/src/app/group/group.resolver.ts
@@ -18,9 +18,9 @@ import { PaginatedGroupProfilesResponse } from '@lib/domains/group/application/q
 import { FindGroupProfilesArgs } from '@lib/domains/group/application/queries/find-group-profiles/find-group-profiles.args';
 import { FindGroupProfilesQuery } from '@lib/domains/group/application/queries/find-group-profiles/find-group-profiles.query';
 import { UseGuards } from '@nestjs/common';
-import { GqlThrottlerGuard } from '../throttler/gql-throttler.guard';
+import { GqlThrottlerBehindProxyGuard } from '../throttler/gql-throttler-behind-proxy.guard';
 
-@UseGuards(GqlThrottlerGuard)
+@UseGuards(GqlThrottlerBehindProxyGuard)
 @Resolver()
 export class GroupResolver {
   constructor(

--- a/apps/api/src/app/group/group.resolver.ts
+++ b/apps/api/src/app/group/group.resolver.ts
@@ -17,7 +17,10 @@ import { FindGroupPreviewsQuery } from '@lib/domains/group/application/queries/f
 import { PaginatedGroupProfilesResponse } from '@lib/domains/group/application/queries/find-group-profiles/paginated-group-profiles.response';
 import { FindGroupProfilesArgs } from '@lib/domains/group/application/queries/find-group-profiles/find-group-profiles.args';
 import { FindGroupProfilesQuery } from '@lib/domains/group/application/queries/find-group-profiles/find-group-profiles.query';
+import { UseGuards } from '@nestjs/common';
+import { GqlThrottlerGuard } from '../throttler/gql-throttler.guard';
 
+@UseGuards(GqlThrottlerGuard)
 @Resolver()
 export class GroupResolver {
   constructor(

--- a/apps/api/src/app/member/member.resolver.ts
+++ b/apps/api/src/app/member/member.resolver.ts
@@ -14,9 +14,9 @@ import { ConnectRolesCommand } from '@lib/domains/member/application/commands/co
 import { DisconnectRolesInput } from '@lib/domains/member/application/commands/disconnect-roles/disconnect-roles.input';
 import { DisconnectRolesCommand } from '@lib/domains/member/application/commands/disconnect-roles/disconnect-roles.command';
 import { UseGuards } from '@nestjs/common';
-import { GqlThrottlerGuard } from '../throttler/gql-throttler.guard';
+import { GqlThrottlerBehindProxyGuard } from '../throttler/gql-throttler-behind-proxy.guard';
 
-@UseGuards(GqlThrottlerGuard)
+@UseGuards(GqlThrottlerBehindProxyGuard)
 @Resolver()
 export class MemberResolver {
   constructor(

--- a/apps/api/src/app/member/member.resolver.ts
+++ b/apps/api/src/app/member/member.resolver.ts
@@ -13,7 +13,10 @@ import { ConnectRolesInput } from '@lib/domains/member/application/commands/conn
 import { ConnectRolesCommand } from '@lib/domains/member/application/commands/connect-roles/connect-roles.command';
 import { DisconnectRolesInput } from '@lib/domains/member/application/commands/disconnect-roles/disconnect-roles.input';
 import { DisconnectRolesCommand } from '@lib/domains/member/application/commands/disconnect-roles/disconnect-roles.command';
+import { UseGuards } from '@nestjs/common';
+import { GqlThrottlerGuard } from '../throttler/gql-throttler.guard';
 
+@UseGuards(GqlThrottlerGuard)
 @Resolver()
 export class MemberResolver {
   constructor(

--- a/apps/api/src/app/offer/offer.resolver.ts
+++ b/apps/api/src/app/offer/offer.resolver.ts
@@ -12,9 +12,9 @@ import { PaginatedOfferPreviewsResponse } from '@lib/domains/offer/application/q
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { Args, ID, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { UseGuards } from '@nestjs/common';
-import { GqlThrottlerGuard } from '../throttler/gql-throttler.guard';
+import { GqlThrottlerBehindProxyGuard } from '../throttler/gql-throttler-behind-proxy.guard';
 
-@UseGuards(GqlThrottlerGuard)
+@UseGuards(GqlThrottlerBehindProxyGuard)
 @Resolver()
 export class OfferResolver {
   constructor(

--- a/apps/api/src/app/offer/offer.resolver.ts
+++ b/apps/api/src/app/offer/offer.resolver.ts
@@ -11,7 +11,10 @@ import { FindOfferPreviewsQuery } from '@lib/domains/offer/application/queries/f
 import { PaginatedOfferPreviewsResponse } from '@lib/domains/offer/application/queries/find-offer-previews/paginated-offer-previews.response';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { Args, ID, Mutation, Query, Resolver } from '@nestjs/graphql';
+import { UseGuards } from '@nestjs/common';
+import { GqlThrottlerGuard } from '../throttler/gql-throttler.guard';
 
+@UseGuards(GqlThrottlerGuard)
 @Resolver()
 export class OfferResolver {
   constructor(

--- a/apps/api/src/app/role/role.resolver.ts
+++ b/apps/api/src/app/role/role.resolver.ts
@@ -8,9 +8,9 @@ import { UpdateRoleInput } from '@lib/domains/role/application/commands/update-r
 import { UpdateRoleCommand } from '@lib/domains/role/application/commands/update-role/update-role.command';
 import { DeleteRoleCommand } from '@lib/domains/role/application/commands/delete-role/delete-role.command';
 import { UseGuards } from '@nestjs/common';
-import { GqlThrottlerGuard } from '../throttler/gql-throttler.guard';
+import { GqlThrottlerBehindProxyGuard } from '../throttler/gql-throttler-behind-proxy.guard';
 
-@UseGuards(GqlThrottlerGuard)
+@UseGuards(GqlThrottlerBehindProxyGuard)
 @Resolver()
 export class RoleResolver {
   constructor(

--- a/apps/api/src/app/role/role.resolver.ts
+++ b/apps/api/src/app/role/role.resolver.ts
@@ -7,7 +7,10 @@ import { CreateRoleCommand } from '@lib/domains/role/application/commands/create
 import { UpdateRoleInput } from '@lib/domains/role/application/commands/update-role/update-role.input';
 import { UpdateRoleCommand } from '@lib/domains/role/application/commands/update-role/update-role.command';
 import { DeleteRoleCommand } from '@lib/domains/role/application/commands/delete-role/delete-role.command';
+import { UseGuards } from '@nestjs/common';
+import { GqlThrottlerGuard } from '../throttler/gql-throttler.guard';
 
+@UseGuards(GqlThrottlerGuard)
 @Resolver()
 export class RoleResolver {
   constructor(

--- a/apps/api/src/app/session/session.resolver.ts
+++ b/apps/api/src/app/session/session.resolver.ts
@@ -8,9 +8,9 @@ import { UpdateSessionCommand } from '@lib/domains/session/application/commands/
 import { DeleteSessionCommand } from '@lib/domains/session/application/commands/delete-session/delete-session.command';
 import { SessionResponse } from '@lib/domains/session/application/dtos/session.response';
 import { UseGuards } from '@nestjs/common';
-import { GqlThrottlerGuard } from '../throttler/gql-throttler.guard';
+import { GqlThrottlerBehindProxyGuard } from '../throttler/gql-throttler-behind-proxy.guard';
 
-@UseGuards(GqlThrottlerGuard)
+@UseGuards(GqlThrottlerBehindProxyGuard)
 @Resolver()
 export class SessionResolver {
   constructor(

--- a/apps/api/src/app/session/session.resolver.ts
+++ b/apps/api/src/app/session/session.resolver.ts
@@ -7,7 +7,10 @@ import { UpdateSessionInput } from '@lib/domains/session/application/commands/up
 import { UpdateSessionCommand } from '@lib/domains/session/application/commands/update-session/update-session.command';
 import { DeleteSessionCommand } from '@lib/domains/session/application/commands/delete-session/delete-session.command';
 import { SessionResponse } from '@lib/domains/session/application/dtos/session.response';
+import { UseGuards } from '@nestjs/common';
+import { GqlThrottlerGuard } from '../throttler/gql-throttler.guard';
 
+@UseGuards(GqlThrottlerGuard)
 @Resolver()
 export class SessionResolver {
   constructor(

--- a/apps/api/src/app/social-account/social-account.resolver.ts
+++ b/apps/api/src/app/social-account/social-account.resolver.ts
@@ -6,7 +6,10 @@ import { UpdateSocialAccountCommand } from '@lib/domains/social-account/applicat
 import { UpdateSocialAccountInput } from '@lib/domains/social-account/application/commands/update-social-account/update-social-account.input';
 import { DeleteSocialAccountCommand } from '@lib/domains/social-account/application/commands/delete-social-account/delete-social-account.command';
 import { DeleteSocialAccountByProviderCommand } from '@lib/domains/social-account/application/commands/delete-social-account-by-provider/delete-social-account-by-provider.command';
+import { UseGuards } from '@nestjs/common';
+import { GqlThrottlerGuard } from '../throttler/gql-throttler.guard';
 
+@UseGuards(GqlThrottlerGuard)
 @Resolver()
 export class SocialAccountResolver {
   constructor(private readonly commandBus: CommandBus) {}

--- a/apps/api/src/app/social-account/social-account.resolver.ts
+++ b/apps/api/src/app/social-account/social-account.resolver.ts
@@ -7,9 +7,9 @@ import { UpdateSocialAccountInput } from '@lib/domains/social-account/applicatio
 import { DeleteSocialAccountCommand } from '@lib/domains/social-account/application/commands/delete-social-account/delete-social-account.command';
 import { DeleteSocialAccountByProviderCommand } from '@lib/domains/social-account/application/commands/delete-social-account-by-provider/delete-social-account-by-provider.command';
 import { UseGuards } from '@nestjs/common';
-import { GqlThrottlerGuard } from '../throttler/gql-throttler.guard';
+import { GqlThrottlerBehindProxyGuard } from '../throttler/gql-throttler-behind-proxy.guard';
 
-@UseGuards(GqlThrottlerGuard)
+@UseGuards(GqlThrottlerBehindProxyGuard)
 @Resolver()
 export class SocialAccountResolver {
   constructor(private readonly commandBus: CommandBus) {}

--- a/apps/api/src/app/swap/swap.resolver.ts
+++ b/apps/api/src/app/swap/swap.resolver.ts
@@ -12,9 +12,9 @@ import { PaginatedSwapPreviewsResponse } from '@lib/domains/swap/application/que
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { Args, ID, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { UseGuards } from '@nestjs/common';
-import { GqlThrottlerGuard } from '../throttler/gql-throttler.guard';
+import { GqlThrottlerBehindProxyGuard } from '../throttler/gql-throttler-behind-proxy.guard';
 
-@UseGuards(GqlThrottlerGuard)
+@UseGuards(GqlThrottlerBehindProxyGuard)
 @Resolver()
 export class SwapResolver {
   constructor(

--- a/apps/api/src/app/swap/swap.resolver.ts
+++ b/apps/api/src/app/swap/swap.resolver.ts
@@ -11,7 +11,10 @@ import { FindSwapPreviewsQuery } from '@lib/domains/swap/application/queries/fin
 import { PaginatedSwapPreviewsResponse } from '@lib/domains/swap/application/queries/find-swap-previews/paginated-swap-previews.response';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { Args, ID, Mutation, Query, Resolver } from '@nestjs/graphql';
+import { UseGuards } from '@nestjs/common';
+import { GqlThrottlerGuard } from '../throttler/gql-throttler.guard';
 
+@UseGuards(GqlThrottlerGuard)
 @Resolver()
 export class SwapResolver {
   constructor(

--- a/apps/api/src/app/term/term.resolver.ts
+++ b/apps/api/src/app/term/term.resolver.ts
@@ -1,8 +1,11 @@
 import { TermResponse } from '@lib/domains/term/application/dtos/term.response';
 import { FindTermQuery } from '@lib/domains/term/application/queries/find-term/find-term.query';
+import { UseGuards } from '@nestjs/common';
 import { QueryBus } from '@nestjs/cqrs';
 import { Args, Query, Resolver } from '@nestjs/graphql';
+import { GqlThrottlerGuard } from '../throttler/gql-throttler.guard';
 
+@UseGuards(GqlThrottlerGuard)
 @Resolver()
 export class TermResolver {
   constructor(private readonly queryBus: QueryBus) {}

--- a/apps/api/src/app/term/term.resolver.ts
+++ b/apps/api/src/app/term/term.resolver.ts
@@ -3,9 +3,9 @@ import { FindTermQuery } from '@lib/domains/term/application/queries/find-term/f
 import { UseGuards } from '@nestjs/common';
 import { QueryBus } from '@nestjs/cqrs';
 import { Args, Query, Resolver } from '@nestjs/graphql';
-import { GqlThrottlerGuard } from '../throttler/gql-throttler.guard';
+import { GqlThrottlerBehindProxyGuard } from '../throttler/gql-throttler-behind-proxy.guard';
 
-@UseGuards(GqlThrottlerGuard)
+@UseGuards(GqlThrottlerBehindProxyGuard)
 @Resolver()
 export class TermResolver {
   constructor(private readonly queryBus: QueryBus) {}

--- a/apps/api/src/app/throttler/gql-throttler-behind-proxy.guard.ts
+++ b/apps/api/src/app/throttler/gql-throttler-behind-proxy.guard.ts
@@ -1,9 +1,9 @@
 import { ExecutionContext, Injectable } from '@nestjs/common';
 import { GqlExecutionContext } from '@nestjs/graphql';
-import { ThrottlerGuard } from '@nestjs/throttler';
+import { ThrottlerBehindProxyGuard } from './throttler-behind-proxy.guard';
 
 @Injectable()
-export class GqlThrottlerGuard extends ThrottlerGuard {
+export class GqlThrottlerBehindProxyGuard extends ThrottlerBehindProxyGuard {
   protected getRequestResponse(context: ExecutionContext): {
     req: Record<string, any>;
     res: Record<string, any>;

--- a/apps/api/src/app/throttler/gql-throttler.guard.ts
+++ b/apps/api/src/app/throttler/gql-throttler.guard.ts
@@ -1,0 +1,15 @@
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { GqlExecutionContext } from '@nestjs/graphql';
+import { ThrottlerGuard } from '@nestjs/throttler';
+
+@Injectable()
+export class GqlThrottlerGuard extends ThrottlerGuard {
+  protected getRequestResponse(context: ExecutionContext): {
+    req: Record<string, any>;
+    res: Record<string, any>;
+  } {
+    const gqlCtx = GqlExecutionContext.create(context);
+    const ctx = gqlCtx.getContext();
+    return { req: ctx.req, res: ctx.res };
+  }
+}

--- a/apps/api/src/app/throttler/throttler-behind-proxy.guard.ts
+++ b/apps/api/src/app/throttler/throttler-behind-proxy.guard.ts
@@ -1,0 +1,13 @@
+import { ThrottlerGuard } from '@nestjs/throttler';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ThrottlerBehindProxyGuard extends ThrottlerGuard {
+  protected getTracker(req: Record<string, any>): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      // individualize IP extraction to meet your own needs
+      const tracker = req.ips.length > 0 ? req.ips[0] : req.ip;
+      resolve(tracker);
+    });
+  }
+}

--- a/apps/api/src/app/user-image/user-image.resolver.ts
+++ b/apps/api/src/app/user-image/user-image.resolver.ts
@@ -12,9 +12,9 @@ import { FindUserImageByIdQuery } from '@lib/domains/user-image/application/quer
 import { UseGuards } from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { Args, ID, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { GqlThrottlerGuard } from '../throttler/gql-throttler.guard';
+import { GqlThrottlerBehindProxyGuard } from '../throttler/gql-throttler-behind-proxy.guard';
 
-@UseGuards(GqlThrottlerGuard)
+@UseGuards(GqlThrottlerBehindProxyGuard)
 @Resolver()
 export class UserImageResolver {
   constructor(

--- a/apps/api/src/app/user-image/user-image.resolver.ts
+++ b/apps/api/src/app/user-image/user-image.resolver.ts
@@ -9,9 +9,12 @@ import { UserImageResponse } from '@lib/domains/user-image/application/dtos/user
 import { FindUserImagesOfRefArgs } from '@lib/domains/user-image/application/queries/find-user-iamges-of-ref/find-user-images-of-ref.args';
 import { FindUserImagesOfRefQuery } from '@lib/domains/user-image/application/queries/find-user-iamges-of-ref/find-user-images-of-ref.query';
 import { FindUserImageByIdQuery } from '@lib/domains/user-image/application/queries/find-user-image-by-id/find-user-image-by-id.query';
+import { UseGuards } from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { Args, ID, Mutation, Query, Resolver } from '@nestjs/graphql';
+import { GqlThrottlerGuard } from '../throttler/gql-throttler.guard';
 
+@UseGuards(GqlThrottlerGuard)
 @Resolver()
 export class UserImageResolver {
   constructor(

--- a/apps/api/src/app/user/user.resolver.ts
+++ b/apps/api/src/app/user/user.resolver.ts
@@ -16,7 +16,9 @@ import { FindUserArgs } from '@lib/domains/user/application/queries/find-user/fi
 import { FindUserQuery } from '@lib/domains/user/application/queries/find-user/find-user.query';
 import { UseGuards } from '@nestjs/common';
 import { JwtAccessAuthGuard } from '../auth/jwt/jwt-acess-auth.guard';
+import { GqlThrottlerGuard } from '../throttler/gql-throttler.guard';
 
+@UseGuards(GqlThrottlerGuard)
 @Resolver()
 export class UserResolver {
   constructor(

--- a/apps/api/src/app/user/user.resolver.ts
+++ b/apps/api/src/app/user/user.resolver.ts
@@ -16,9 +16,9 @@ import { FindUserArgs } from '@lib/domains/user/application/queries/find-user/fi
 import { FindUserQuery } from '@lib/domains/user/application/queries/find-user/find-user.query';
 import { UseGuards } from '@nestjs/common';
 import { JwtAccessAuthGuard } from '../auth/jwt/jwt-acess-auth.guard';
-import { GqlThrottlerGuard } from '../throttler/gql-throttler.guard';
+import { GqlThrottlerBehindProxyGuard } from '../throttler/gql-throttler-behind-proxy.guard';
 
-@UseGuards(GqlThrottlerGuard)
+@UseGuards(GqlThrottlerBehindProxyGuard)
 @Resolver()
 export class UserResolver {
   constructor(

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -483,23 +483,23 @@ type Query {
   findAuctions(cursor: ID, productCategoryId: ID, skip: Int! = 1, take: Int!): PaginatedAuctionsResponse!
   findDemand(slug: String!): DemandResponse
   findDemandById(id: ID!): DemandResponse
-  findDemandPreviews(cursor: ID, keyword: String, orderBy: JSON, skip: Int! = 1, take: Int!, where: JSON): PaginatedDemandPreviewsResponse!
+  findDemandPreviews(cursor: ID, distinct: Boolean, keyword: String, orderBy: JSON, skip: Int! = 1, take: Int!, where: JSON): PaginatedDemandPreviewsResponse!
   findGroup(slug: String): GroupResponse
   findGroupById(id: ID!): GroupResponse
   findGroupPreviews: [GroupPreviewResponse!]!
-  findGroupProfiles(cursor: ID, keyword: String, skip: Int! = 1, take: Int!): PaginatedGroupProfilesResponse!
+  findGroupProfiles(cursor: ID, distinct: Boolean, keyword: String, skip: Int! = 1, take: Int!): PaginatedGroupProfilesResponse!
   findGroups(cursor: ID, skip: Int! = 1, take: Int!): PaginatedGroupsResponse!
   findMemberByUserAndGroup(groupId: ID!, userId: ID!): MemberWithRolesResponse
   findMyUserById(id: ID!): MyUserResponse
   findMyUserByUsername(username: ID!): MyUserResponse
   findOffer(slug: String!): OfferResponse
   findOfferById(id: ID!): OfferResponse
-  findOfferPreviews(cursor: ID, keyword: String, orderBy: JSON, skip: Int! = 1, take: Int!, where: JSON): PaginatedOfferPreviewsResponse!
+  findOfferPreviews(cursor: ID, distinct: Boolean, keyword: String, orderBy: JSON, skip: Int! = 1, take: Int!, where: JSON): PaginatedOfferPreviewsResponse!
   findRoleById(id: ID!): RoleResponse
   findSession(sessionToken: String!): SessionResponse
   findSwap(slug: String!): SwapResponse
   findSwapById(id: ID!): SwapResponse
-  findSwapPreviews(cursor: ID, keyword: String, orderBy: JSON, skip: Int! = 1, take: Int!, where: JSON): PaginatedSwapPreviewsResponse!
+  findSwapPreviews(cursor: ID, distinct: Boolean, keyword: String, orderBy: JSON, skip: Int! = 1, take: Int!, where: JSON): PaginatedSwapPreviewsResponse!
   findTerm(name: String!): TermResponse
   findUser(provider: String, sessionToken: String, socialId: String): UserResponse
   findUserImageById(id: ID!): UserImageResponse

--- a/libs/domains/src/demand/application/queries/find-demand-previews/find-demand-previews.handler.ts
+++ b/libs/domains/src/demand/application/queries/find-demand-previews/find-demand-previews.handler.ts
@@ -44,6 +44,7 @@ export class FindDemandPreviewsHandler extends PrismaQueryHandler<
           createdAt: query.orderBy?.createdAt,
         },
       ],
+      distinct: query.distinct ? ['name', 'buyerId'] : undefined,
     });
 
     return paginate<DemandPreviewResponse>(

--- a/libs/domains/src/demand/application/queries/find-demand-previews/find-demand-previews.handler.ts
+++ b/libs/domains/src/demand/application/queries/find-demand-previews/find-demand-previews.handler.ts
@@ -36,7 +36,14 @@ export class FindDemandPreviewsHandler extends PrismaQueryHandler<
           },
         },
       },
-      orderBy: query.orderBy,
+      orderBy: [
+        {
+          price: query.orderBy?.price,
+        },
+        {
+          createdAt: query.orderBy?.createdAt,
+        },
+      ],
     });
 
     return paginate<DemandPreviewResponse>(

--- a/libs/domains/src/demand/application/queries/find-demand-previews/find-demand-previews.handler.ts
+++ b/libs/domains/src/demand/application/queries/find-demand-previews/find-demand-previews.handler.ts
@@ -25,6 +25,11 @@ export class FindDemandPreviewsHandler extends PrismaQueryHandler<
       where: {
         ...query.where,
         name: parseFollowedBySearcher(query.keyword),
+        createdAt: query.where?.createdAt
+          ? {
+              gt: new Date(query.where.createdAt.gt),
+            }
+          : undefined,
       },
       cursor,
       take: query.take + 1,

--- a/libs/domains/src/demand/application/queries/find-demand-previews/find-demand-previews.query.ts
+++ b/libs/domains/src/demand/application/queries/find-demand-previews/find-demand-previews.query.ts
@@ -10,10 +10,13 @@ export class FindDemandPreviewsQuery extends PaginationQuery {
 
   keyword?: string;
 
+  distinct?: boolean;
+
   constructor(findDemandPreviewsArgs: FindDemandPreviewsArgs) {
     super(findDemandPreviewsArgs);
     this.where = findDemandPreviewsArgs.where;
     this.orderBy = findDemandPreviewsArgs.orderBy;
     this.keyword = findDemandPreviewsArgs.keyword;
+    this.distinct = findDemandPreviewsArgs.distinct;
   }
 }

--- a/libs/domains/src/offer/application/queries/find-offer-previews/find-offer-previews.handler.ts
+++ b/libs/domains/src/offer/application/queries/find-offer-previews/find-offer-previews.handler.ts
@@ -36,7 +36,14 @@ export class FindOfferPreviewsHandler extends PrismaQueryHandler<
           },
         },
       },
-      orderBy: query.orderBy,
+      orderBy: [
+        {
+          price: query.orderBy?.price,
+        },
+        {
+          createdAt: query.orderBy?.createdAt,
+        },
+      ],
     });
     const offerPreviewPromises = offers.map(async (offer) => {
       const thumbnail = await this.prismaService.userImage.findFirst({

--- a/libs/domains/src/offer/application/queries/find-offer-previews/find-offer-previews.handler.ts
+++ b/libs/domains/src/offer/application/queries/find-offer-previews/find-offer-previews.handler.ts
@@ -44,6 +44,7 @@ export class FindOfferPreviewsHandler extends PrismaQueryHandler<
           createdAt: query.orderBy?.createdAt,
         },
       ],
+      distinct: query.distinct ? ['name', 'sellerId'] : undefined,
     });
     const offerPreviewPromises = offers.map(async (offer) => {
       const thumbnail = await this.prismaService.userImage.findFirst({

--- a/libs/domains/src/offer/application/queries/find-offer-previews/find-offer-previews.handler.ts
+++ b/libs/domains/src/offer/application/queries/find-offer-previews/find-offer-previews.handler.ts
@@ -25,6 +25,11 @@ export class FindOfferPreviewsHandler extends PrismaQueryHandler<
       where: {
         ...query.where,
         name: parseFollowedBySearcher(query.keyword),
+        createdAt: query.where?.createdAt
+          ? {
+              gt: new Date(query.where.createdAt.gt),
+            }
+          : undefined,
       },
       cursor,
       take: query.take + 1,

--- a/libs/domains/src/offer/application/queries/find-offer-previews/find-offer-previews.query.ts
+++ b/libs/domains/src/offer/application/queries/find-offer-previews/find-offer-previews.query.ts
@@ -10,10 +10,13 @@ export class FindOfferPreviewsQuery extends PaginationQuery {
 
   keyword?: string;
 
+  distinct?: boolean;
+
   constructor(findOfferPreviewsArgs: FindOfferPreviewsArgs) {
     super(findOfferPreviewsArgs);
     this.where = findOfferPreviewsArgs.where;
     this.orderBy = findOfferPreviewsArgs.orderBy;
     this.keyword = findOfferPreviewsArgs.keyword;
+    this.distinct = findOfferPreviewsArgs.distinct;
   }
 }

--- a/libs/domains/src/swap/application/queries/find-swap-previews/find-swap-previews.handler.ts
+++ b/libs/domains/src/swap/application/queries/find-swap-previews/find-swap-previews.handler.ts
@@ -54,6 +54,7 @@ export class FindSwapPreviewsHandler extends PrismaQueryHandler<
           },
         },
       },
+      distinct: query.distinct ? ['name0', 'name1', 'proposerId'] : undefined,
     });
     const swapPreviewPromises = swaps.map(async (swap) => {
       const thumbnail = await this.prismaService.userImage.findFirst({

--- a/libs/domains/src/swap/application/queries/find-swap-previews/find-swap-previews.handler.ts
+++ b/libs/domains/src/swap/application/queries/find-swap-previews/find-swap-previews.handler.ts
@@ -39,7 +39,14 @@ export class FindSwapPreviewsHandler extends PrismaQueryHandler<
       cursor,
       take: query.take + 1,
       skip: query.skip,
-      orderBy: query.orderBy,
+      orderBy: [
+        {
+          price: query.orderBy?.price,
+        },
+        {
+          createdAt: query.orderBy?.createdAt,
+        },
+      ],
       include: {
         proposer: {
           select: {

--- a/libs/domains/src/swap/application/queries/find-swap-previews/find-swap-previews.handler.ts
+++ b/libs/domains/src/swap/application/queries/find-swap-previews/find-swap-previews.handler.ts
@@ -35,6 +35,11 @@ export class FindSwapPreviewsHandler extends PrismaQueryHandler<
               },
             ]
           : undefined,
+        createdAt: query.where?.createdAt
+          ? {
+              gt: new Date(query.where.createdAt.gt),
+            }
+          : undefined,
       },
       cursor,
       take: query.take + 1,

--- a/libs/domains/src/swap/application/queries/find-swap-previews/find-swap-previews.query.ts
+++ b/libs/domains/src/swap/application/queries/find-swap-previews/find-swap-previews.query.ts
@@ -10,10 +10,13 @@ export class FindSwapPreviewsQuery extends PaginationQuery {
 
   keyword?: string;
 
+  distinct?: boolean;
+
   constructor(findSwapPreviewsArgs: FindSwapPreviewsArgs) {
     super(findSwapPreviewsArgs);
     this.where = findSwapPreviewsArgs.where;
     this.orderBy = findSwapPreviewsArgs.orderBy;
     this.keyword = findSwapPreviewsArgs.keyword;
+    this.distinct = findSwapPreviewsArgs.distinct;
   }
 }

--- a/libs/shared/src/cqrs/queries/pagination/pagination-search.args.ts
+++ b/libs/shared/src/cqrs/queries/pagination/pagination-search.args.ts
@@ -8,4 +8,8 @@ export class PaginationSearchArgs extends PaginationArgs {
   @IsString()
   @Field(() => String, { nullable: true })
   keyword?: string;
+
+  @IsOptional()
+  @Field(() => Boolean, { nullable: true })
+  distinct?: boolean;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2486,6 +2486,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nestjs/throttler@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "@nestjs/throttler@npm:5.1.2"
+  peerDependencies:
+    "@nestjs/common": ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
+    "@nestjs/core": ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
+    reflect-metadata: ^0.1.13 || ^0.2.0
+  checksum: 181c99fca712be09ce9264e0b3f505f450d07d19cdacd58ca2e66c9f29e143ac3a8051a3cdc0b928f162ae0c0b14d40fc68752434d46c9b25e555974a1c8c1a1
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -4704,6 +4715,7 @@ __metadata:
     "@nestjs/schematics": ^10.0.1
     "@nestjs/swagger": ^7.1.6
     "@nestjs/testing": ^10.2.4
+    "@nestjs/throttler": ^5.1.2
     "@types/cache-manager-redis-store": ^2.0.1
     "@types/cookie-parser": ^1.4.6
     "@types/express": ^4.17.17


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
1. find Previews에서의 중복 제거
2. api 분당 요청수 제한

## 어떻게 해결했나요?
1. prisma findMany에서 distinct 옵션 사용
2. throttler module을 통한 ttl, limit 설정, proxy ip 처리

## 참고 자료
https://www.prisma.io/docs/orm/prisma-client/queries/aggregation-grouping-summarizing#select-distinct
https://docs.nestjs.com/security/rate-limiting