### PR TITLE
feat: include reports in offer, demand, swap responses

### DIFF
--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -94,7 +94,7 @@ type CommentResponse {
   parentId: ID
   postId: ID
   reportId: ID
-  type: DateTime!
+  type: String!
   updatedAt: DateTime!
 }
 
@@ -294,6 +294,7 @@ type DemandPreviewResponse {
   price: Int!
   priceCurrency: String!
   productCategoryId: String!
+  reports: [ReportResponse!]!
   slug: String
   source: String!
   status: String!
@@ -319,6 +320,7 @@ type DemandResponse {
   price: Int!
   priceCurrency: String!
   productCategoryId: String!
+  reports: [ReportWithAuthorResponse!]!
   slug: String
   source: String!
   status: String!
@@ -463,6 +465,7 @@ type OfferPreviewResponse {
   price: Int!
   priceCurrency: String!
   productCategoryId: String!
+  reports: [ReportResponse!]!
   seller: UserResponse!
   slug: String
   source: String!
@@ -489,6 +492,7 @@ type OfferResponse {
   price: Int!
   priceCurrency: String!
   productCategoryId: String!
+  reports: [ReportWithAuthorResponse!]!
   seller: AuthorResponse!
   slug: String
   source: String!
@@ -582,6 +586,19 @@ type Query {
 }
 
 type ReportResponse {
+  content: String
+  createdAt: DateTime!
+  demandId: ID
+  id: ID!
+  offerId: ID
+  status: String!
+  swapId: ID
+  title: String!
+  type: String!
+  updatedAt: DateTime!
+}
+
+type ReportWithAuthorResponse {
   author: AuthorResponse!
   content: String
   createdAt: DateTime!
@@ -591,7 +608,7 @@ type ReportResponse {
   status: String!
   swapId: ID
   title: String!
-  type: DateTime!
+  type: String!
   updatedAt: DateTime!
 }
 
@@ -655,6 +672,7 @@ type SwapPreviewResponse {
   priceCurrency: String!
   productCategoryId: String!
   proposer: UserResponse!
+  reports: [ReportResponse!]!
   slug: String
   source: String!
   status: String!
@@ -683,6 +701,7 @@ type SwapResponse {
   priceCurrency: String!
   productCategoryId: String!
   proposer: AuthorResponse!
+  reports: [ReportWithAuthorResponse!]!
   slug: String
   source: String!
   status: String!

--- a/libs/domains/src/comment/application/dtos/comment.response.ts
+++ b/libs/domains/src/comment/application/dtos/comment.response.ts
@@ -13,7 +13,7 @@ export class CommentResponse {
   updatedAt: Date;
 
   @Field()
-  type: Date;
+  type: string;
 
   @Field(() => AuthorResponse)
   author: AuthorResponse;

--- a/libs/domains/src/demand/application/dtos/demand-preview.response.ts
+++ b/libs/domains/src/demand/application/dtos/demand-preview.response.ts
@@ -1,5 +1,6 @@
 import { Field, ID, ObjectType, Int } from '@nestjs/graphql';
 import { UserResponse } from '@lib/domains/user/application/dtos/user.response';
+import { ReportResponse } from '@lib/domains/report/application/dtos/report.response';
 
 @ObjectType()
 export class DemandPreviewResponse {
@@ -47,6 +48,9 @@ export class DemandPreviewResponse {
 
   @Field()
   source: string;
+
+  @Field(() => [ReportResponse])
+  reports: ReportResponse[];
 
   constructor(partial: Partial<DemandPreviewResponse>) {
     Object.assign(this, partial);

--- a/libs/domains/src/demand/application/dtos/demand.response.ts
+++ b/libs/domains/src/demand/application/dtos/demand.response.ts
@@ -2,6 +2,7 @@ import { Field, ID, ObjectType, Int } from '@nestjs/graphql';
 import { UserImageResponse } from '@lib/domains/user-image/application/dtos/user-image.response';
 import { AuthorResponse } from '@lib/domains/user/application/dtos/author.response';
 import { GroupProfileResponse } from '@lib/domains/group/application/dtos/group-profile.response';
+import { ReportWithAuthorResponse } from '@lib/domains/report/application/dtos/report-with-author.response';
 
 @ObjectType()
 export class DemandResponse {
@@ -55,6 +56,9 @@ export class DemandResponse {
 
   @Field()
   source: string;
+
+  @Field(() => [ReportWithAuthorResponse])
+  reports: ReportWithAuthorResponse[];
 
   constructor(partial: Partial<DemandResponse>) {
     Object.assign(this, partial);

--- a/libs/domains/src/demand/application/queries/find-demand-by-id/find-demand-by-id.handler.ts
+++ b/libs/domains/src/demand/application/queries/find-demand-by-id/find-demand-by-id.handler.ts
@@ -32,6 +32,27 @@ export class FindDemandByIdHandler extends PrismaQueryHandler<FindDemandByIdQuer
             socialAccounts: true,
           },
         },
+        reports: {
+          include: {
+            author: {
+              include: {
+                members: {
+                  include: {
+                    roles: {
+                      orderBy: {
+                        position: 'asc',
+                      },
+                    },
+                  },
+                },
+                socialAccounts: true,
+              },
+            },
+          },
+          orderBy: {
+            createdAt: 'desc',
+          },
+        },
       },
     });
     if (!demand) throw new NotFoundException(DemandErrorMessage.DEMAND_IS_NOT_FOUND);

--- a/libs/domains/src/demand/application/queries/find-demand-previews/find-demand-previews.handler.ts
+++ b/libs/domains/src/demand/application/queries/find-demand-previews/find-demand-previews.handler.ts
@@ -44,6 +44,11 @@ export class FindDemandPreviewsHandler extends PrismaQueryHandler<
             bot: true,
           },
         },
+        reports: {
+          orderBy: {
+            createdAt: 'desc',
+          },
+        },
       },
       orderBy: [
         {

--- a/libs/domains/src/demand/application/queries/find-demand/find-demand.handler.ts
+++ b/libs/domains/src/demand/application/queries/find-demand/find-demand.handler.ts
@@ -35,6 +35,27 @@ export class FindDemandHandler extends PrismaQueryHandler<FindDemandQuery, Deman
             socialAccounts: true,
           },
         },
+        reports: {
+          include: {
+            author: {
+              include: {
+                members: {
+                  include: {
+                    roles: {
+                      orderBy: {
+                        position: 'asc',
+                      },
+                    },
+                  },
+                },
+                socialAccounts: true,
+              },
+            },
+          },
+          orderBy: {
+            createdAt: 'desc',
+          },
+        },
       },
     });
     if (!demand) throw new NotFoundException(DemandErrorMessage.DEMAND_IS_NOT_FOUND);

--- a/libs/domains/src/group/application/queries/find-group-previews/find-group-previews.handler.ts
+++ b/libs/domains/src/group/application/queries/find-group-previews/find-group-previews.handler.ts
@@ -34,6 +34,11 @@ export class FindGroupPreviewsHandler extends PrismaQueryHandler<
                 bot: true,
               },
             },
+            reports: {
+              orderBy: {
+                createdAt: 'desc',
+              },
+            },
           },
           orderBy: {
             bumpedAt: 'desc',
@@ -49,6 +54,11 @@ export class FindGroupPreviewsHandler extends PrismaQueryHandler<
                 username: true,
                 avatarURL: true,
                 bot: true,
+              },
+            },
+            reports: {
+              orderBy: {
+                createdAt: 'desc',
               },
             },
           },

--- a/libs/domains/src/offer/application/dtos/offer-preview.response.ts
+++ b/libs/domains/src/offer/application/dtos/offer-preview.response.ts
@@ -35,9 +35,6 @@ export class OfferPreviewResponse {
   @Field()
   status: string;
 
-  @Field()
-  source: string;
-
   @Field(() => UserImageResponse, { nullable: true })
   thumbnail: UserImageResponse | null;
 
@@ -52,6 +49,9 @@ export class OfferPreviewResponse {
 
   @Field(() => String, { nullable: true })
   brandId: string | null;
+
+  @Field()
+  source: string;
 
   @Field(() => [ReportResponse])
   reports: ReportResponse[];

--- a/libs/domains/src/offer/application/dtos/offer-preview.response.ts
+++ b/libs/domains/src/offer/application/dtos/offer-preview.response.ts
@@ -1,6 +1,7 @@
 import { Field, ID, ObjectType, Int } from '@nestjs/graphql';
 import { UserImageResponse } from '@lib/domains/user-image/application/dtos/user-image.response';
 import { UserResponse } from '@lib/domains/user/application/dtos/user.response';
+import { ReportResponse } from '@lib/domains/report/application/dtos/report.response';
 
 @ObjectType()
 export class OfferPreviewResponse {
@@ -51,6 +52,9 @@ export class OfferPreviewResponse {
 
   @Field(() => String, { nullable: true })
   brandId: string | null;
+
+  @Field(() => [ReportResponse])
+  reports: ReportResponse[];
 
   constructor(partial: Partial<OfferPreviewResponse>) {
     Object.assign(this, partial);

--- a/libs/domains/src/offer/application/dtos/offer.response.ts
+++ b/libs/domains/src/offer/application/dtos/offer.response.ts
@@ -2,6 +2,7 @@ import { Field, ID, ObjectType, Int } from '@nestjs/graphql';
 import { UserImageResponse } from '@lib/domains/user-image/application/dtos/user-image.response';
 import { AuthorResponse } from '@lib/domains/user/application/dtos/author.response';
 import { GroupProfileResponse } from '@lib/domains/group/application/dtos/group-profile.response';
+import { ReportWithAuthorResponse } from '@lib/domains/report/application/dtos/report-with-author.response';
 
 @ObjectType()
 export class OfferResponse {
@@ -58,6 +59,9 @@ export class OfferResponse {
 
   @Field(() => String, { nullable: true })
   brandId: string | null;
+
+  @Field(() => [ReportWithAuthorResponse])
+  reports: ReportWithAuthorResponse[];
 
   constructor(partial: Partial<OfferResponse>) {
     Object.assign(this, partial);

--- a/libs/domains/src/offer/application/queries/find-offer-by-id/find-offer-by-id.handler.ts
+++ b/libs/domains/src/offer/application/queries/find-offer-by-id/find-offer-by-id.handler.ts
@@ -32,6 +32,27 @@ export class FindOfferByIdHandler extends PrismaQueryHandler<FindOfferByIdQuery,
             socialAccounts: true,
           },
         },
+        reports: {
+          include: {
+            author: {
+              include: {
+                members: {
+                  include: {
+                    roles: {
+                      orderBy: {
+                        position: 'asc',
+                      },
+                    },
+                  },
+                },
+                socialAccounts: true,
+              },
+            },
+          },
+          orderBy: {
+            createdAt: 'desc',
+          },
+        },
       },
     });
     if (!offer) throw new NotFoundException(OfferErrorMessage.OFFER_IS_NOT_FOUND);

--- a/libs/domains/src/offer/application/queries/find-offer-previews/find-offer-previews.handler.ts
+++ b/libs/domains/src/offer/application/queries/find-offer-previews/find-offer-previews.handler.ts
@@ -44,6 +44,11 @@ export class FindOfferPreviewsHandler extends PrismaQueryHandler<
             bot: true,
           },
         },
+        reports: {
+          orderBy: {
+            createdAt: 'desc',
+          },
+        },
       },
       orderBy: [
         {
@@ -55,6 +60,7 @@ export class FindOfferPreviewsHandler extends PrismaQueryHandler<
       ],
       distinct: query.distinct ? ['name', 'sellerId'] : undefined,
     });
+
     const offerPreviewPromises = offers.map(async (offer) => {
       const thumbnail = await this.prismaService.userImage.findFirst({
         where: {

--- a/libs/domains/src/offer/application/queries/find-offer-previews/find-offer-previews.handler.ts
+++ b/libs/domains/src/offer/application/queries/find-offer-previews/find-offer-previews.handler.ts
@@ -77,6 +77,7 @@ export class FindOfferPreviewsHandler extends PrismaQueryHandler<
         thumbnail,
       };
     });
+
     return paginate<OfferPreviewResponse>(
       this.parseResponses(await Promise.all(offerPreviewPromises)),
       'id',

--- a/libs/domains/src/offer/application/queries/find-offer/find-offer.handler.ts
+++ b/libs/domains/src/offer/application/queries/find-offer/find-offer.handler.ts
@@ -35,6 +35,11 @@ export class FindOfferHandler extends PrismaQueryHandler<FindOfferQuery, OfferRe
             socialAccounts: true,
           },
         },
+        reports: {
+          orderBy: {
+            createdAt: 'desc',
+          },
+        },
       },
     });
     if (!offer) throw new NotFoundException(OfferErrorMessage.OFFER_IS_NOT_FOUND);

--- a/libs/domains/src/offer/application/queries/find-offer/find-offer.handler.ts
+++ b/libs/domains/src/offer/application/queries/find-offer/find-offer.handler.ts
@@ -36,6 +36,22 @@ export class FindOfferHandler extends PrismaQueryHandler<FindOfferQuery, OfferRe
           },
         },
         reports: {
+          include: {
+            author: {
+              include: {
+                members: {
+                  include: {
+                    roles: {
+                      orderBy: {
+                        position: 'asc',
+                      },
+                    },
+                  },
+                },
+                socialAccounts: true,
+              },
+            },
+          },
           orderBy: {
             createdAt: 'desc',
           },

--- a/libs/domains/src/report/application/dtos/report-with-author.response.ts
+++ b/libs/domains/src/report/application/dtos/report-with-author.response.ts
@@ -1,0 +1,14 @@
+import { AuthorResponse } from '@lib/domains/user/application/dtos/author.response';
+import { Field, ObjectType } from '@nestjs/graphql';
+import { ReportResponse } from './report.response';
+
+@ObjectType()
+export class ReportWithAuthorResponse extends ReportResponse {
+  @Field(() => AuthorResponse)
+  author: AuthorResponse;
+
+  constructor(partial: Partial<ReportWithAuthorResponse>) {
+    super(partial);
+    Object.assign(this, partial);
+  }
+}

--- a/libs/domains/src/report/application/dtos/report.response.ts
+++ b/libs/domains/src/report/application/dtos/report.response.ts
@@ -1,4 +1,3 @@
-import { AuthorResponse } from '@lib/domains/user/application/dtos/author.response';
 import { Field, ID, ObjectType } from '@nestjs/graphql';
 
 @ObjectType()
@@ -13,7 +12,7 @@ export class ReportResponse {
   updatedAt: Date;
 
   @Field()
-  type: Date;
+  type: string;
 
   @Field(() => ID, { nullable: true })
   offerId: string | null;
@@ -24,17 +23,14 @@ export class ReportResponse {
   @Field(() => ID, { nullable: true })
   swapId: string | null;
 
-  @Field(() => AuthorResponse)
-  author: AuthorResponse;
+  @Field()
+  status: string;
 
   @Field(() => String)
   title: string;
 
   @Field(() => String, { nullable: true })
   content: string | null;
-
-  @Field()
-  status: string;
 
   constructor(partial: Partial<ReportResponse>) {
     Object.assign(this, partial);

--- a/libs/domains/src/swap/application/dtos/swap-preview.response.ts
+++ b/libs/domains/src/swap/application/dtos/swap-preview.response.ts
@@ -1,6 +1,7 @@
 import { Field, ID, ObjectType, Int } from '@nestjs/graphql';
 import { UserImageResponse } from '@lib/domains/user-image/application/dtos/user-image.response';
 import { UserResponse } from '@lib/domains/user/application/dtos/user.response';
+import { ReportResponse } from '@lib/domains/report/application/dtos/report.response';
 
 @ObjectType()
 export class SwapPreviewResponse {
@@ -54,6 +55,9 @@ export class SwapPreviewResponse {
 
   @Field()
   source: string;
+
+  @Field(() => [ReportResponse])
+  reports: ReportResponse[];
 
   constructor(partial: Partial<SwapPreviewResponse>) {
     Object.assign(this, partial);

--- a/libs/domains/src/swap/application/dtos/swap.response.ts
+++ b/libs/domains/src/swap/application/dtos/swap.response.ts
@@ -2,6 +2,7 @@ import { Field, ID, ObjectType, Int } from '@nestjs/graphql';
 import { UserImageResponse } from '@lib/domains/user-image/application/dtos/user-image.response';
 import { AuthorResponse } from '@lib/domains/user/application/dtos/author.response';
 import { GroupProfileResponse } from '@lib/domains/group/application/dtos/group-profile.response';
+import { ReportWithAuthorResponse } from '@lib/domains/report/application/dtos/report-with-author.response';
 
 @ObjectType()
 export class SwapResponse {
@@ -64,6 +65,9 @@ export class SwapResponse {
 
   @Field()
   source: string;
+
+  @Field(() => [ReportWithAuthorResponse])
+  reports: ReportWithAuthorResponse[];
 
   constructor(partial: Partial<SwapResponse>) {
     Object.assign(this, partial);

--- a/libs/domains/src/swap/application/queries/find-swap-by-id/find-swap-by-id.handler.ts
+++ b/libs/domains/src/swap/application/queries/find-swap-by-id/find-swap-by-id.handler.ts
@@ -32,6 +32,27 @@ export class FindSwapByIdHandler extends PrismaQueryHandler<FindSwapByIdQuery, S
             socialAccounts: true,
           },
         },
+        reports: {
+          include: {
+            author: {
+              include: {
+                members: {
+                  include: {
+                    roles: {
+                      orderBy: {
+                        position: 'asc',
+                      },
+                    },
+                  },
+                },
+                socialAccounts: true,
+              },
+            },
+          },
+          orderBy: {
+            createdAt: 'desc',
+          },
+        },
       },
     });
     if (!swap) throw new NotFoundException(SwapErrorMessage.SWAP_IS_NOT_FOUND);

--- a/libs/domains/src/swap/application/queries/find-swap-previews/find-swap-previews.handler.ts
+++ b/libs/domains/src/swap/application/queries/find-swap-previews/find-swap-previews.handler.ts
@@ -62,6 +62,11 @@ export class FindSwapPreviewsHandler extends PrismaQueryHandler<
             bot: true,
           },
         },
+        reports: {
+          orderBy: {
+            createdAt: 'desc',
+          },
+        },
       },
       distinct: query.distinct ? ['name0', 'name1', 'proposerId'] : undefined,
     });

--- a/libs/domains/src/swap/application/queries/find-swap/find-swap.handler.ts
+++ b/libs/domains/src/swap/application/queries/find-swap/find-swap.handler.ts
@@ -35,6 +35,27 @@ export class FindSwapHandler extends PrismaQueryHandler<FindSwapQuery, SwapRespo
             socialAccounts: true,
           },
         },
+        reports: {
+          include: {
+            author: {
+              include: {
+                members: {
+                  include: {
+                    roles: {
+                      orderBy: {
+                        position: 'asc',
+                      },
+                    },
+                  },
+                },
+                socialAccounts: true,
+              },
+            },
+          },
+          orderBy: {
+            createdAt: 'desc',
+          },
+        },
       },
     });
     if (!swap) throw new NotFoundException(SwapErrorMessage.SWAP_IS_NOT_FOUND);


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
offer, demand, swap query 결과에 reports 추가

## 어떻게 해결했나요?
1. FindPreviews에는 ReportResponse를 포함
2. Find에는 ReportWithAuthorResponse를 포함