### PR TITLE
feat: check deal status before delete, filter hidden status in find queries

### DIFF
--- a/apps/api/src/app/comment/comment.resolver.ts
+++ b/apps/api/src/app/comment/comment.resolver.ts
@@ -8,6 +8,9 @@ import { FindCommentArgs } from '@lib/domains/comment/application/queries/find-c
 import { FindCommentQuery } from '@lib/domains/comment/application/queries/find-comment/find-comment.query';
 import { UpdateCommentCommand } from '@lib/domains/comment/application/commands/update-comment/update-comment.command';
 import { UpdateCommentInput } from '@lib/domains/comment/application/commands/update-comment/update-comment.input';
+import { JwtAccessAuthGuard } from '@lib/domains/auth/guards/jwt/jwt-access-auth.guard';
+import { AuthorIdPath } from '@lib/domains/auth/decorators/author-id-path/author-id-path.decorator';
+import { AuthorGuard } from '@lib/domains/auth/guards/author/author.guard';
 import { GqlThrottlerBehindProxyGuard } from '../throttler/gql-throttler-behind-proxy.guard';
 
 @UseGuards(GqlThrottlerBehindProxyGuard)
@@ -24,12 +27,16 @@ export class CommentResolver {
     return this.queryBus.execute(query);
   }
 
+  @AuthorIdPath('input.authorId')
+  @UseGuards(JwtAccessAuthGuard, AuthorGuard)
   @Mutation(() => String)
   async createComment(@Args('input') input: CreateCommentInput): Promise<string> {
     await this.commandBus.execute(new CreateCommentCommand(input));
     return input.id;
   }
 
+  @AuthorIdPath('input.authorId')
+  @UseGuards(JwtAccessAuthGuard, AuthorGuard)
   @Mutation(() => CommentResponse)
   async updateComment(@Args('input') input: UpdateCommentInput) {
     return this.commandBus.execute(new UpdateCommentCommand(input));

--- a/apps/api/src/app/demand/demand.resolver.ts
+++ b/apps/api/src/app/demand/demand.resolver.ts
@@ -56,7 +56,7 @@ export class DemandResolver {
     return this.commandBus.execute(new UpdateDemandCommand(input));
   }
 
-  @AuthorIdPath('input.buyerId')
+  @AuthorIdPath('buyerId')
   @UseGuards(JwtAccessAuthGuard, AuthorGuard)
   @Mutation(() => String)
   async deleteDemand(@Args() args: DeleteDemandArgs): Promise<string> {

--- a/apps/api/src/app/demand/demand.resolver.ts
+++ b/apps/api/src/app/demand/demand.resolver.ts
@@ -19,6 +19,8 @@ import { AuthorGuard } from '@lib/domains/auth/guards/author/author.guard';
 import { BumpDemandInput } from '@lib/domains/demand/application/commands/bump-demand/bump-demand.input';
 import { BumpDemandCommand } from '@lib/domains/demand/application/commands/bump-demand/bump-demand.command';
 import { DemandPreviewResponse } from '@lib/domains/demand/application/dtos/demand-preview.response';
+import { JwtAccessAllGuard } from '@lib/domains/auth/guards/jwt/jwt-access-all.guard';
+import { AuthUser } from '@lib/domains/auth/decorators/auth-user/auth-user.decorator';
 import { GqlThrottlerBehindProxyGuard } from '../throttler/gql-throttler-behind-proxy.guard';
 
 @UseGuards(GqlThrottlerBehindProxyGuard)
@@ -29,15 +31,29 @@ export class DemandResolver {
     private readonly commandBus: CommandBus,
   ) {}
 
+  @UseGuards(JwtAccessAllGuard)
   @Query(() => DemandResponse, { nullable: true })
-  async findDemand(@Args() findDemandArgs: FindDemandArgs): Promise<DemandResponse | null> {
-    const query = new FindDemandQuery(findDemandArgs);
+  async findDemand(
+    @Args() findDemandArgs: FindDemandArgs,
+    @AuthUser() user: any,
+  ): Promise<DemandResponse | null> {
+    const query = new FindDemandQuery({
+      args: findDemandArgs,
+      userId: user?.id,
+    });
     return this.queryBus.execute(query);
   }
 
+  @UseGuards(JwtAccessAllGuard)
   @Query(() => PaginatedDemandPreviewsResponse)
-  async findDemandPreviews(@Args() findDemandPreviewsArgs: FindDemandPreviewsArgs) {
-    const query = new FindDemandPreviewsQuery(findDemandPreviewsArgs);
+  async findDemandPreviews(
+    @Args() findDemandPreviewsArgs: FindDemandPreviewsArgs,
+    @AuthUser() user: any,
+  ) {
+    const query = new FindDemandPreviewsQuery({
+      args: findDemandPreviewsArgs,
+      userId: user?.id,
+    });
     return this.queryBus.execute(query);
   }
 

--- a/apps/api/src/app/discord-message/discord-message.resolver.ts
+++ b/apps/api/src/app/discord-message/discord-message.resolver.ts
@@ -1,8 +1,6 @@
-import { CreateDiscordMessageCommand } from '@lib/domains/discord-message/application/commands/create-discord-message/create-discord-message.command';
-import { CreateDiscordMessageInput } from '@lib/domains/discord-message/application/commands/create-discord-message/create-discord-message.input';
 import { UseGuards } from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
-import { Args, Mutation, Resolver } from '@nestjs/graphql';
+import { Resolver } from '@nestjs/graphql';
 import { GqlThrottlerBehindProxyGuard } from '../throttler/gql-throttler-behind-proxy.guard';
 
 @UseGuards(GqlThrottlerBehindProxyGuard)
@@ -12,10 +10,4 @@ export class DiscordMessageResolver {
     private readonly commandBus: CommandBus,
     private readonly queryBus: QueryBus,
   ) {}
-
-  @Mutation(() => String)
-  async createDiscordMessage(@Args('input') input: CreateDiscordMessageInput): Promise<string> {
-    await this.commandBus.execute(new CreateDiscordMessageCommand(input));
-    return input.modelId;
-  }
 }

--- a/apps/api/src/app/offer/offer.resolver.ts
+++ b/apps/api/src/app/offer/offer.resolver.ts
@@ -19,6 +19,8 @@ import { DeleteOfferArgs } from '@lib/domains/offer/application/commands/delete-
 import { BumpOfferInput } from '@lib/domains/offer/application/commands/bump-offer/bump-offer.input';
 import { BumpOfferCommand } from '@lib/domains/offer/application/commands/bump-offer/bump-offer.command';
 import { OfferPreviewResponse } from '@lib/domains/offer/application/dtos/offer-preview.response';
+import { AuthUser } from '@lib/domains/auth/decorators/auth-user/auth-user.decorator';
+import { JwtAccessAllGuard } from '@lib/domains/auth/guards/jwt/jwt-access-all.guard';
 import { GqlThrottlerBehindProxyGuard } from '../throttler/gql-throttler-behind-proxy.guard';
 
 @UseGuards(GqlThrottlerBehindProxyGuard)
@@ -35,9 +37,16 @@ export class OfferResolver {
     return this.queryBus.execute(query);
   }
 
+  @UseGuards(JwtAccessAllGuard)
   @Query(() => PaginatedOfferPreviewsResponse)
-  async findOfferPreviews(@Args() findOfferPreviewsArgs: FindOfferPreviewsArgs) {
-    const query = new FindOfferPreviewsQuery(findOfferPreviewsArgs);
+  async findOfferPreviews(
+    @Args() findOfferPreviewsArgs: FindOfferPreviewsArgs,
+    @AuthUser() user: any,
+  ) {
+    const query = new FindOfferPreviewsQuery({
+      args: findOfferPreviewsArgs,
+      userId: user?.id,
+    });
     return this.queryBus.execute(query);
   }
 

--- a/apps/api/src/app/offer/offer.resolver.ts
+++ b/apps/api/src/app/offer/offer.resolver.ts
@@ -31,9 +31,16 @@ export class OfferResolver {
     private readonly commandBus: CommandBus,
   ) {}
 
+  @UseGuards(JwtAccessAllGuard)
   @Query(() => OfferResponse, { nullable: true })
-  async findOffer(@Args() findOfferArgs: FindOfferArgs): Promise<OfferResponse | null> {
-    const query = new FindOfferQuery(findOfferArgs);
+  async findOffer(
+    @Args() findOfferArgs: FindOfferArgs,
+    @AuthUser() user: any,
+  ): Promise<OfferResponse | null> {
+    const query = new FindOfferQuery({
+      args: findOfferArgs,
+      userId: user?.id,
+    });
     return this.queryBus.execute(query);
   }
 

--- a/apps/api/src/app/offer/offer.resolver.ts
+++ b/apps/api/src/app/offer/offer.resolver.ts
@@ -56,7 +56,7 @@ export class OfferResolver {
     return this.commandBus.execute(new UpdateOfferCommand(input));
   }
 
-  @AuthorIdPath('input.sellerId')
+  @AuthorIdPath('sellerId')
   @UseGuards(JwtAccessAuthGuard, AuthorGuard)
   @Mutation(() => String)
   async deleteOffer(@Args() args: DeleteOfferArgs): Promise<string> {

--- a/apps/api/src/app/report/report.resolver.ts
+++ b/apps/api/src/app/report/report.resolver.ts
@@ -11,6 +11,9 @@ import { FindReportPreviewsArgs } from '@lib/domains/report/application/queries/
 import { FindReportPreviewsQuery } from '@lib/domains/report/application/queries/find-report-previews/find-report-previews.query';
 import { CommentReportInput } from '@lib/domains/report/application/commands/comment-report/comment-report.input';
 import { CommentReportCommand } from '@lib/domains/report/application/commands/comment-report/comment-report.command';
+import { JwtAccessAuthGuard } from '@lib/domains/auth/guards/jwt/jwt-access-auth.guard';
+import { AuthorGuard } from '@lib/domains/auth/guards/author/author.guard';
+import { AuthorIdPath } from '@lib/domains/auth/decorators/author-id-path/author-id-path.decorator';
 import { GqlThrottlerBehindProxyGuard } from '../throttler/gql-throttler-behind-proxy.guard';
 
 @UseGuards(GqlThrottlerBehindProxyGuard)
@@ -33,12 +36,16 @@ export class ReportResolver {
     return this.queryBus.execute(query);
   }
 
+  @AuthorIdPath('input.authorId')
+  @UseGuards(JwtAccessAuthGuard, AuthorGuard)
   @Mutation(() => String)
   async createReport(@Args('input') input: CreateReportInput): Promise<string> {
     await this.commandBus.execute(new CreateReportCommand(input));
     return input.id;
   }
 
+  @AuthorIdPath('input.authorId')
+  @UseGuards(JwtAccessAuthGuard, AuthorGuard)
   @Mutation(() => String)
   async commentReport(@Args('input') input: CommentReportInput): Promise<string> {
     await this.commandBus.execute(new CommentReportCommand(input));

--- a/apps/api/src/app/session/session.resolver.ts
+++ b/apps/api/src/app/session/session.resolver.ts
@@ -1,12 +1,5 @@
-import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
+import { Resolver } from '@nestjs/graphql';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
-import { FindSessionQuery } from '@lib/domains/session/application/queries/find-session/find-session.query';
-import { CreateSessionInput } from '@lib/domains/session/application/commands/create-session/create-session.input';
-import { CreateSessionCommand } from '@lib/domains/session/application/commands/create-session/create-session.command';
-import { UpdateSessionInput } from '@lib/domains/session/application/commands/update-session/update-session.input';
-import { UpdateSessionCommand } from '@lib/domains/session/application/commands/update-session/update-session.command';
-import { DeleteSessionCommand } from '@lib/domains/session/application/commands/delete-session/delete-session.command';
-import { SessionResponse } from '@lib/domains/session/application/dtos/session.response';
 import { UseGuards } from '@nestjs/common';
 import { GqlThrottlerBehindProxyGuard } from '../throttler/gql-throttler-behind-proxy.guard';
 
@@ -17,27 +10,4 @@ export class SessionResolver {
     private readonly commandBus: CommandBus,
     private readonly queryBus: QueryBus,
   ) {}
-
-  @Query(() => SessionResponse, { nullable: true })
-  async findSession(@Args('sessionToken') sessionToken: string) {
-    return this.queryBus.execute(new FindSessionQuery(sessionToken));
-  }
-
-  @Mutation(() => String)
-  async createSession(@Args('input') input: CreateSessionInput): Promise<string> {
-    await this.commandBus.execute(new CreateSessionCommand(input));
-    return input.id;
-  }
-
-  @Mutation(() => String)
-  async updateSession(@Args('input') input: UpdateSessionInput): Promise<string> {
-    await this.commandBus.execute(new UpdateSessionCommand(input));
-    return input.sessionToken;
-  }
-
-  @Mutation(() => String)
-  async deleteSession(@Args('sessionToken') sessionToken: string): Promise<string> {
-    await this.commandBus.execute(new DeleteSessionCommand(sessionToken));
-    return sessionToken;
-  }
 }

--- a/apps/api/src/app/swap/swap.resolver.ts
+++ b/apps/api/src/app/swap/swap.resolver.ts
@@ -56,7 +56,7 @@ export class SwapResolver {
     return this.commandBus.execute(new UpdateSwapCommand(input));
   }
 
-  @AuthorIdPath('input.proposerId')
+  @AuthorIdPath('proposerId')
   @UseGuards(JwtAccessAuthGuard, AuthorGuard)
   @Mutation(() => String)
   async deleteSwap(@Args() args: DeleteSwapArgs): Promise<string> {

--- a/apps/api/src/app/swap/swap.resolver.ts
+++ b/apps/api/src/app/swap/swap.resolver.ts
@@ -19,6 +19,8 @@ import { AuthorGuard } from '@lib/domains/auth/guards/author/author.guard';
 import { BumpSwapInput } from '@lib/domains/swap/application/commands/bump-swap/bump-swap.input';
 import { BumpSwapCommand } from '@lib/domains/swap/application/commands/bump-swap/bump-swap.command';
 import { SwapPreviewResponse } from '@lib/domains/swap/application/dtos/swap-preview.response';
+import { JwtAccessAllGuard } from '@lib/domains/auth/guards/jwt/jwt-access-all.guard';
+import { AuthUser } from '@lib/domains/auth/decorators/auth-user/auth-user.decorator';
 import { GqlThrottlerBehindProxyGuard } from '../throttler/gql-throttler-behind-proxy.guard';
 
 @UseGuards(GqlThrottlerBehindProxyGuard)
@@ -29,15 +31,29 @@ export class SwapResolver {
     private readonly commandBus: CommandBus,
   ) {}
 
+  @UseGuards(JwtAccessAllGuard)
   @Query(() => SwapResponse, { nullable: true })
-  async findSwap(@Args() findSwapArgs: FindSwapArgs): Promise<SwapResponse | null> {
-    const query = new FindSwapQuery(findSwapArgs);
+  async findSwap(
+    @Args() findSwapArgs: FindSwapArgs,
+    @AuthUser() user: any,
+  ): Promise<SwapResponse | null> {
+    const query = new FindSwapQuery({
+      args: findSwapArgs,
+      userId: user?.id,
+    });
     return this.queryBus.execute(query);
   }
 
+  @UseGuards(JwtAccessAllGuard)
   @Query(() => PaginatedSwapPreviewsResponse)
-  async findSwapPreviews(@Args() findSwapPreviewsArgs: FindSwapPreviewsArgs) {
-    const query = new FindSwapPreviewsQuery(findSwapPreviewsArgs);
+  async findSwapPreviews(
+    @Args() findSwapPreviewsArgs: FindSwapPreviewsArgs,
+    @AuthUser() user: any,
+  ) {
+    const query = new FindSwapPreviewsQuery({
+      args: findSwapPreviewsArgs,
+      userId: user?.id,
+    });
     return this.queryBus.execute(query);
   }
 

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -206,13 +206,6 @@ input CreateRoleInput {
   position: Int
 }
 
-input CreateSessionInput {
-  expires: DateTime!
-  id: ID!
-  sessionToken: String!
-  userId: ID!
-}
-
 input CreateSignedUrlInput {
   filename: String!
   type: String!
@@ -415,7 +408,6 @@ type Mutation {
   createOffer(input: CreateOfferInput!): String!
   createReport(input: CreateReportInput!): String!
   createRole(input: CreateRoleInput!): String!
-  createSession(input: CreateSessionInput!): String!
   createSignedUrl(input: CreateSignedUrlInput!): SignedUrlResponse!
   createSocialAccount(input: CreateSocialAccountInput!): String!
   createSwap(input: CreateSwapInput!): String!
@@ -427,7 +419,6 @@ type Mutation {
   deleteMember(id: ID!, userId: ID!): String!
   deleteOffer(id: ID!, sellerId: ID!): String!
   deleteRole(id: ID!): String!
-  deleteSession(sessionToken: String!): String!
   deleteSocialAccount(id: ID!): String!
   deleteSocialAccountByProvider(provider: String!, socialId: String!): String!
   deleteSwap(id: ID!, proposerId: ID!): String!
@@ -443,7 +434,6 @@ type Mutation {
   updateMember(input: UpdateMemberInput!): String!
   updateOffer(input: UpdateOfferInput!): OfferPreviewResponse!
   updateRole(input: UpdateRoleInput!): String!
-  updateSession(input: UpdateSessionInput!): String!
   updateSocialAccount(input: UpdateSocialAccountInput!): String!
   updateSwap(input: UpdateSwapInput!): SwapPreviewResponse!
   updateUser(input: UpdateUserInput!): String!
@@ -597,7 +587,6 @@ type Query {
   findReport(authorId: ID, id: ID, refId: ID, type: String): ReportResponse!
   findReportPreviews(cursor: ID, distinct: Boolean, keyword: String, orderBy: JSON, skip: Int! = 1, take: Int!, where: JSON): PaginatedReportPreviewsResponse!
   findRoleById(id: ID!): RoleResponse
-  findSession(sessionToken: String!): SessionResponse
   findSwap(id: ID, slug: String): SwapResponse
   findSwapPreviews(cursor: ID, distinct: Boolean, keyword: String, orderBy: JSON, skip: Int! = 1, take: Int!, where: JSON): PaginatedSwapPreviewsResponse!
   findTerm(name: String!): TermResponse
@@ -646,12 +635,6 @@ type RoleResponse {
   id: ID!
   name: String!
   position: Int
-}
-
-type SessionResponse {
-  expires: DateTime!
-  sessionToken: String!
-  userId: String!
 }
 
 type SignedUrlResponse {
@@ -822,12 +805,6 @@ input UpdateRoleInput {
   id: ID!
   name: String
   position: Int
-}
-
-input UpdateSessionInput {
-  expires: DateTime
-  sessionToken: String!
-  userId: ID
 }
 
 input UpdateSocialAccountInput {

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -153,15 +153,6 @@ input CreateDemandInput {
   status: String! = "open"
 }
 
-input CreateDiscordMessageInput {
-  discordChannelId: String
-  discordGuildId: String
-  discordMessageId: String
-  groupId: ID!
-  modelId: ID!
-  modelName: String!
-}
-
 input CreateGroupInput {
   description: String
   icon: String
@@ -418,7 +409,6 @@ type Mutation {
   createAuction(input: CreateAuctionInput!): String!
   createComment(input: CreateCommentInput!): String!
   createDemand(input: CreateDemandInput!): String!
-  createDiscordMessage(input: CreateDiscordMessageInput!): String!
   createGroup(input: CreateGroupInput!): String!
   createManyUserImage(input: CreateManyUserImageInput!): String!
   createMember(input: CreateMemberInput!): String!

--- a/libs/domains/src/auth/guards/jwt/jwt-access-all.guard.ts
+++ b/libs/domains/src/auth/guards/jwt/jwt-access-all.guard.ts
@@ -1,0 +1,22 @@
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { GqlExecutionContext } from '@nestjs/graphql';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtAccessAllGuard extends AuthGuard('jwt-access') {
+  getRequest(context: ExecutionContext) {
+    const ctx = GqlExecutionContext.create(context);
+    const { req } = ctx.getContext();
+    return req;
+  }
+
+  handleRequest<TUser = any>(
+    err: any,
+    user: any,
+    info: any,
+    context: ExecutionContext,
+    status?: any,
+  ): TUser {
+    return user;
+  }
+}

--- a/libs/domains/src/demand/application/commands/delete-demand/delete-demand.handler.ts
+++ b/libs/domains/src/demand/application/commands/delete-demand/delete-demand.handler.ts
@@ -17,6 +17,8 @@ export class DeleteDemandHandler implements ICommandHandler<DeleteDemandCommand>
     if (!demand) throw new NotFoundException(DemandErrorMessage.DEMAND_NOT_FOUND);
     if (!demand.isAuthorized(command.buyerId))
       throw new ForbiddenException(DemandErrorMessage.DEMAND_DELETE_COMMAND_FROM_UNAUTHORIZED_USER);
+    if (demand.hasUncommentedReports())
+      throw new ForbiddenException(DemandErrorMessage.UNCOMMENTED_REPORT_EXISTS);
 
     await this.demandSavePort.delete(demand);
   }

--- a/libs/domains/src/demand/application/commands/update-demand/update-demand.handler.ts
+++ b/libs/domains/src/demand/application/commands/update-demand/update-demand.handler.ts
@@ -26,6 +26,8 @@ export class UpdateDemandHandler extends PrismaCommandHandler<
     if (!demand) throw new NotFoundException(DemandErrorMessage.DEMAND_NOT_FOUND);
     if (!demand.isAuthorized(command.buyerId))
       throw new ForbiddenException(DemandErrorMessage.DEMAND_CHANGES_FROM_UNAUTHORIZED_USER);
+    if (demand.hasUncommentedReports())
+      throw new ForbiddenException(DemandErrorMessage.UNCOMMENTED_REPORT_EXISTS);
 
     demand = this.publisher.mergeObjectContext(demand);
     demand.update(

--- a/libs/domains/src/demand/application/queries/find-demand-previews/find-demand-previews.query.ts
+++ b/libs/domains/src/demand/application/queries/find-demand-previews/find-demand-previews.query.ts
@@ -1,10 +1,10 @@
 import { PaginationQuery } from '@lib/shared/cqrs/queries/pagination/pagination.query';
-import { FindOffersWhereArgs } from '@lib/domains/offer/application/queries/find-offer-previews/find-offers-where.args';
 import { FindOffersOrderByArgs } from '@lib/domains/offer/application/queries/find-offer-previews/find-offers-order-by.args';
 import { FindDemandPreviewsArgs } from './find-demand-previews.args';
+import { FindDemandsWhereArgs } from './find-demands-where.args';
 
 export class FindDemandPreviewsQuery extends PaginationQuery {
-  where?: FindOffersWhereArgs;
+  where?: FindDemandsWhereArgs;
 
   orderBy?: FindOffersOrderByArgs;
 
@@ -12,11 +12,14 @@ export class FindDemandPreviewsQuery extends PaginationQuery {
 
   distinct?: boolean;
 
-  constructor(findDemandPreviewsArgs: FindDemandPreviewsArgs) {
-    super(findDemandPreviewsArgs);
-    this.where = findDemandPreviewsArgs.where;
-    this.orderBy = findDemandPreviewsArgs.orderBy;
-    this.keyword = findDemandPreviewsArgs.keyword;
-    this.distinct = findDemandPreviewsArgs.distinct;
+  userId?: string;
+
+  constructor({ args, userId }: { args: FindDemandPreviewsArgs; userId?: string }) {
+    super(args);
+    this.where = args.where;
+    this.orderBy = args.orderBy;
+    this.keyword = args.keyword;
+    this.distinct = args.distinct;
+    this.userId = userId;
   }
 }

--- a/libs/domains/src/demand/application/queries/find-demand-previews/find-demands-where.args.ts
+++ b/libs/domains/src/demand/application/queries/find-demand-previews/find-demands-where.args.ts
@@ -1,0 +1,28 @@
+import { ArgsType, Field, ID } from '@nestjs/graphql';
+import { IsOptional } from 'class-validator';
+import { GraphQLJSON } from 'graphql-type-json';
+
+@ArgsType()
+export class FindDemandsWhereArgs {
+  @IsOptional()
+  @Field(() => ID, { nullable: true })
+  groupId?: string;
+
+  @IsOptional()
+  @Field(() => ID, { nullable: true })
+  productCategoryId?: string;
+
+  @IsOptional()
+  @Field(() => ID, { nullable: true })
+  buyerId?: string;
+
+  @IsOptional()
+  @Field(() => String, { nullable: true })
+  status?: string;
+
+  @IsOptional()
+  @Field(() => GraphQLJSON, { nullable: true })
+  bumpedAt?: {
+    gt: string;
+  };
+}

--- a/libs/domains/src/demand/application/queries/find-demand/find-demand.query.ts
+++ b/libs/domains/src/demand/application/queries/find-demand/find-demand.query.ts
@@ -6,8 +6,11 @@ export class FindDemandQuery implements IQuery {
 
   slug?: string;
 
-  constructor(findDemandArgs: FindDemandArgs) {
-    this.id = findDemandArgs.id;
-    this.slug = findDemandArgs.slug;
+  userId?: string;
+
+  constructor({ args, userId }: { args: FindDemandArgs; userId?: string }) {
+    this.id = args.id;
+    this.slug = args.slug;
+    this.userId = userId;
   }
 }

--- a/libs/domains/src/demand/domain/demand.constants.ts
+++ b/libs/domains/src/demand/domain/demand.constants.ts
@@ -1,2 +1,4 @@
 export const DEMAND_OPEN = 'open';
+export const DEMAND_CLOSED = 'closed';
 export const DEMAND_PENDING = 'pending';
+export const DEMAND_HIDDEN = 'hidden';

--- a/libs/domains/src/demand/domain/demand.entity.ts
+++ b/libs/domains/src/demand/domain/demand.entity.ts
@@ -111,4 +111,8 @@ export class DemandEntity extends AggregateRoot {
       this.status = DEMAND_OPEN;
     }
   }
+
+  hasUncommentedReports() {
+    return this.reportCount - this.reportCommentCount > 0;
+  }
 }

--- a/libs/domains/src/demand/domain/demand.error.message.ts
+++ b/libs/domains/src/demand/domain/demand.error.message.ts
@@ -6,4 +6,5 @@ export enum DemandErrorMessage {
   DEMAND_BUMP_STUCK_ON_COOLDOWN = 'Demand bump stuck on cooldown',
   DEMAND_REPORT_NOT_FOUND = 'Demand report not found',
   COMMENT_DEMAND_REPORT_REQUEST_FROM_NON_BUYER = 'Comment demand report request from non buyer',
+  UNCOMMENTED_REPORT_EXISTS = 'Uncommented report exists',
 }

--- a/libs/domains/src/demand/domain/demand.error.message.ts
+++ b/libs/domains/src/demand/domain/demand.error.message.ts
@@ -7,4 +7,5 @@ export enum DemandErrorMessage {
   DEMAND_REPORT_NOT_FOUND = 'Demand report not found',
   COMMENT_DEMAND_REPORT_REQUEST_FROM_NON_BUYER = 'Comment demand report request from non buyer',
   UNCOMMENTED_REPORT_EXISTS = 'Uncommented report exists',
+  FIND_REQUEST_FROM_UNAUTHORIZED_USER = 'Find request from unauthorized user',
 }

--- a/libs/domains/src/offer/application/commands/delete-offer/delete-offer.handler.ts
+++ b/libs/domains/src/offer/application/commands/delete-offer/delete-offer.handler.ts
@@ -17,6 +17,8 @@ export class DeleteOfferHandler implements ICommandHandler<DeleteOfferCommand> {
     if (!offer) throw new NotFoundException(OfferErrorMessage.OFFER_IS_NOT_FOUND);
     if (!offer.isAuthorized(command.sellerId))
       throw new ForbiddenException(OfferErrorMessage.OFFER_DELETE_COMMAND_FROM_UNAUTHORIZED_USER);
+    if (offer.hasUncommentedReports())
+      throw new ForbiddenException(OfferErrorMessage.UNCOMMENTED_REPORT_EXISTS);
 
     await this.offerSavePort.delete(offer);
   }

--- a/libs/domains/src/offer/application/commands/update-offer/update-offer.handler.ts
+++ b/libs/domains/src/offer/application/commands/update-offer/update-offer.handler.ts
@@ -26,6 +26,8 @@ export class UpdateOfferHandler extends PrismaCommandHandler<
     if (!offer) throw new NotFoundException(OfferErrorMessage.OFFER_IS_NOT_FOUND);
     if (!offer.isAuthorized(command.sellerId))
       throw new ForbiddenException(OfferErrorMessage.OFFER_CHANGES_FROM_UNAUTHORIZED_USER);
+    if (offer.hasUncommentedReports())
+      throw new ForbiddenException(OfferErrorMessage.UNCOMMENTED_REPORT_EXISTS);
 
     offer = this.publisher.mergeObjectContext(offer);
     offer.update(

--- a/libs/domains/src/offer/application/queries/find-offer-previews/find-offer-previews.query.ts
+++ b/libs/domains/src/offer/application/queries/find-offer-previews/find-offer-previews.query.ts
@@ -12,11 +12,14 @@ export class FindOfferPreviewsQuery extends PaginationQuery {
 
   distinct?: boolean;
 
-  constructor(findOfferPreviewsArgs: FindOfferPreviewsArgs) {
-    super(findOfferPreviewsArgs);
-    this.where = findOfferPreviewsArgs.where;
-    this.orderBy = findOfferPreviewsArgs.orderBy;
-    this.keyword = findOfferPreviewsArgs.keyword;
-    this.distinct = findOfferPreviewsArgs.distinct;
+  userId?: string;
+
+  constructor({ args, userId }: { args: FindOfferPreviewsArgs; userId?: string }) {
+    super(args);
+    this.where = args.where;
+    this.orderBy = args.orderBy;
+    this.keyword = args.keyword;
+    this.distinct = args.distinct;
+    this.userId = userId;
   }
 }

--- a/libs/domains/src/offer/application/queries/find-offer/find-offer.handler.ts
+++ b/libs/domains/src/offer/application/queries/find-offer/find-offer.handler.ts
@@ -1,9 +1,10 @@
 import { QueryHandler } from '@nestjs/cqrs';
 import { PrismaQueryHandler } from '@lib/shared/cqrs/queries/handlers/prisma-query.handler';
-import { NotFoundException } from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { OfferErrorMessage } from '@lib/domains/offer/domain/offer.error.message';
 import { FindOfferQuery } from './find-offer.query';
 import { OfferResponse } from '../../dtos/offer.response';
+import { OFFER_HIDDEN } from '@lib/domains/offer/domain/offer.constants';
 
 @QueryHandler(FindOfferQuery)
 export class FindOfferHandler extends PrismaQueryHandler<FindOfferQuery, OfferResponse> {
@@ -38,6 +39,8 @@ export class FindOfferHandler extends PrismaQueryHandler<FindOfferQuery, OfferRe
       },
     });
     if (!offer) throw new NotFoundException(OfferErrorMessage.OFFER_IS_NOT_FOUND);
+    if (offer.status === OFFER_HIDDEN && offer.sellerId !== query.userId)
+      throw new ForbiddenException(OfferErrorMessage.FIND_REQUEST_FROM_UNAUTHORIZED_USER);
 
     const images = await this.prismaService.userImage.findMany({
       where: {

--- a/libs/domains/src/offer/application/queries/find-offer/find-offer.handler.ts
+++ b/libs/domains/src/offer/application/queries/find-offer/find-offer.handler.ts
@@ -2,9 +2,9 @@ import { QueryHandler } from '@nestjs/cqrs';
 import { PrismaQueryHandler } from '@lib/shared/cqrs/queries/handlers/prisma-query.handler';
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { OfferErrorMessage } from '@lib/domains/offer/domain/offer.error.message';
+import { OFFER_HIDDEN } from '@lib/domains/offer/domain/offer.constants';
 import { FindOfferQuery } from './find-offer.query';
 import { OfferResponse } from '../../dtos/offer.response';
-import { OFFER_HIDDEN } from '@lib/domains/offer/domain/offer.constants';
 
 @QueryHandler(FindOfferQuery)
 export class FindOfferHandler extends PrismaQueryHandler<FindOfferQuery, OfferResponse> {

--- a/libs/domains/src/offer/application/queries/find-offer/find-offer.query.ts
+++ b/libs/domains/src/offer/application/queries/find-offer/find-offer.query.ts
@@ -6,8 +6,11 @@ export class FindOfferQuery implements IQuery {
 
   slug?: string;
 
-  constructor(findOfferArgs: FindOfferArgs) {
-    this.id = findOfferArgs.id;
-    this.slug = findOfferArgs.slug;
+  userId?: string;
+
+  constructor({ args, userId }: { args: FindOfferArgs; userId?: string }) {
+    this.id = args.id;
+    this.slug = args.slug;
+    this.userId = userId;
   }
 }

--- a/libs/domains/src/offer/domain/offer.constants.ts
+++ b/libs/domains/src/offer/domain/offer.constants.ts
@@ -1,2 +1,4 @@
 export const OFFER_OPEN = 'open';
+export const OFFER_CLOSED = 'closed';
 export const OFFER_PENDING = 'pending';
+export const OFFER_HIDDEN = 'hidden';

--- a/libs/domains/src/offer/domain/offer.entity.ts
+++ b/libs/domains/src/offer/domain/offer.entity.ts
@@ -111,4 +111,8 @@ export class OfferEntity extends AggregateRoot {
       this.status = OFFER_OPEN;
     }
   }
+
+  hasUncommentedReports() {
+    return this.reportCount - this.reportCommentCount > 0;
+  }
 }

--- a/libs/domains/src/offer/domain/offer.error.message.ts
+++ b/libs/domains/src/offer/domain/offer.error.message.ts
@@ -7,4 +7,5 @@ export enum OfferErrorMessage {
   OFFER_BUMP_STUCK_ON_COOLDOWN = 'Offer bump stuck on cooldown',
   OFFER_REPORT_NOT_FOUND = 'Offer report not found',
   COMMENT_OFFER_REPORT_REQUEST_FROM_NON_SELLER = 'Comment offer report request from non seller',
+  UNCOMMENTED_REPORT_EXISTS = 'Uncommented report exists',
 }

--- a/libs/domains/src/offer/domain/offer.error.message.ts
+++ b/libs/domains/src/offer/domain/offer.error.message.ts
@@ -8,4 +8,5 @@ export enum OfferErrorMessage {
   OFFER_REPORT_NOT_FOUND = 'Offer report not found',
   COMMENT_OFFER_REPORT_REQUEST_FROM_NON_SELLER = 'Comment offer report request from non seller',
   UNCOMMENTED_REPORT_EXISTS = 'Uncommented report exists',
+  FIND_REQUEST_FROM_UNAUTHORIZED_USER = 'Find request from unauthorized user',
 }

--- a/libs/domains/src/swap/application/commands/delete-swap/delete-swap.handler.ts
+++ b/libs/domains/src/swap/application/commands/delete-swap/delete-swap.handler.ts
@@ -17,6 +17,8 @@ export class DeleteSwapHandler implements ICommandHandler<DeleteSwapCommand> {
     if (!swap) throw new NotFoundException(SwapErrorMessage.SWAP_NOT_FOUND);
     if (!swap.isAuthorized(command.proposerId))
       throw new ForbiddenException(SwapErrorMessage.SWAP_DELETE_COMMAND_FROM_UNAUTHORIZED_USER);
+    if (swap.hasUncommentedReports())
+      throw new ForbiddenException(SwapErrorMessage.UNCOMMENTED_REPORT_EXISTS);
 
     await this.swapSavePort.delete(swap);
   }

--- a/libs/domains/src/swap/application/commands/update-swap/update-swap.handler.ts
+++ b/libs/domains/src/swap/application/commands/update-swap/update-swap.handler.ts
@@ -26,6 +26,8 @@ export class UpdateSwapHandler extends PrismaCommandHandler<
     if (!swap) throw new NotFoundException(SwapErrorMessage.SWAP_NOT_FOUND);
     if (!swap.isAuthorized(command.proposerId))
       throw new ForbiddenException(SwapErrorMessage.SWAP_CHANGES_FROM_UNAUTHORIZED_USER);
+    if (swap.hasUncommentedReports())
+      throw new ForbiddenException(SwapErrorMessage.UNCOMMENTED_REPORT_EXISTS);
 
     swap = this.publisher.mergeObjectContext(swap);
     swap.update(

--- a/libs/domains/src/swap/application/queries/find-swap-previews/find-swap-previews.query.ts
+++ b/libs/domains/src/swap/application/queries/find-swap-previews/find-swap-previews.query.ts
@@ -1,10 +1,10 @@
 import { PaginationQuery } from '@lib/shared/cqrs/queries/pagination/pagination.query';
-import { FindOffersWhereArgs } from '@lib/domains/offer/application/queries/find-offer-previews/find-offers-where.args';
 import { FindOffersOrderByArgs } from '@lib/domains/offer/application/queries/find-offer-previews/find-offers-order-by.args';
 import { FindSwapPreviewsArgs } from './find-swap-previews.args';
+import { FindSwapsWhereArgs } from './find-swaps-where.args';
 
 export class FindSwapPreviewsQuery extends PaginationQuery {
-  where?: FindOffersWhereArgs;
+  where?: FindSwapsWhereArgs;
 
   orderBy?: FindOffersOrderByArgs;
 
@@ -12,11 +12,14 @@ export class FindSwapPreviewsQuery extends PaginationQuery {
 
   distinct?: boolean;
 
-  constructor(findSwapPreviewsArgs: FindSwapPreviewsArgs) {
-    super(findSwapPreviewsArgs);
-    this.where = findSwapPreviewsArgs.where;
-    this.orderBy = findSwapPreviewsArgs.orderBy;
-    this.keyword = findSwapPreviewsArgs.keyword;
-    this.distinct = findSwapPreviewsArgs.distinct;
+  userId?: string;
+
+  constructor({ args, userId }: { args: FindSwapPreviewsArgs; userId?: string }) {
+    super(args);
+    this.where = args.where;
+    this.orderBy = args.orderBy;
+    this.keyword = args.keyword;
+    this.distinct = args.distinct;
+    this.userId = userId;
   }
 }

--- a/libs/domains/src/swap/application/queries/find-swap-previews/find-swaps-where.args.ts
+++ b/libs/domains/src/swap/application/queries/find-swap-previews/find-swaps-where.args.ts
@@ -1,0 +1,28 @@
+import { ArgsType, Field, ID } from '@nestjs/graphql';
+import { IsOptional } from 'class-validator';
+import { GraphQLJSON } from 'graphql-type-json';
+
+@ArgsType()
+export class FindSwapsWhereArgs {
+  @IsOptional()
+  @Field(() => ID, { nullable: true })
+  groupId?: string;
+
+  @IsOptional()
+  @Field(() => ID, { nullable: true })
+  productCategoryId?: string;
+
+  @IsOptional()
+  @Field(() => ID, { nullable: true })
+  proposerId?: string;
+
+  @IsOptional()
+  @Field(() => String, { nullable: true })
+  status?: string;
+
+  @IsOptional()
+  @Field(() => GraphQLJSON, { nullable: true })
+  bumpedAt?: {
+    gt: string;
+  };
+}

--- a/libs/domains/src/swap/application/queries/find-swap/find-swap.handler.ts
+++ b/libs/domains/src/swap/application/queries/find-swap/find-swap.handler.ts
@@ -1,7 +1,8 @@
 import { QueryHandler } from '@nestjs/cqrs';
 import { PrismaQueryHandler } from '@lib/shared/cqrs/queries/handlers/prisma-query.handler';
-import { NotFoundException } from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { SwapErrorMessage } from '@lib/domains/swap/domain/swap.error.message';
+import { SWAP_HIDDEN } from '@lib/domains/swap/domain/swap.constants';
 import { FindSwapQuery } from './find-swap.query';
 import { SwapResponse } from '../../dtos/swap.response';
 
@@ -38,6 +39,8 @@ export class FindSwapHandler extends PrismaQueryHandler<FindSwapQuery, SwapRespo
       },
     });
     if (!swap) throw new NotFoundException(SwapErrorMessage.SWAP_NOT_FOUND);
+    if (swap.status === SWAP_HIDDEN && swap.proposerId !== query.userId)
+      throw new ForbiddenException(SwapErrorMessage.FIND_REQUEST_FROM_UNAUTHORIZED_USER);
 
     const images = await this.prismaService.userImage.findMany({
       where: {

--- a/libs/domains/src/swap/application/queries/find-swap/find-swap.query.ts
+++ b/libs/domains/src/swap/application/queries/find-swap/find-swap.query.ts
@@ -6,8 +6,11 @@ export class FindSwapQuery implements IQuery {
 
   slug?: string;
 
-  constructor(findSwapArgs: FindSwapArgs) {
-    this.id = findSwapArgs.id;
-    this.slug = findSwapArgs.slug;
+  userId?: string;
+
+  constructor({ args, userId }: { args: FindSwapArgs; userId?: string }) {
+    this.id = args.id;
+    this.slug = args.slug;
+    this.userId = userId;
   }
 }

--- a/libs/domains/src/swap/domain/swap.constants.ts
+++ b/libs/domains/src/swap/domain/swap.constants.ts
@@ -1,2 +1,4 @@
 export const SWAP_OPEN = 'open';
+export const SWAP_CLOSED = 'closed';
 export const SWAP_PENDING = 'pending';
+export const SWAP_HIDDEN = 'hidden';

--- a/libs/domains/src/swap/domain/swap.entity.ts
+++ b/libs/domains/src/swap/domain/swap.entity.ts
@@ -115,4 +115,8 @@ export class SwapEntity extends AggregateRoot {
       this.status = SWAP_OPEN;
     }
   }
+
+  hasUncommentedReports() {
+    return this.reportCount - this.reportCommentCount > 0;
+  }
 }

--- a/libs/domains/src/swap/domain/swap.error.message.ts
+++ b/libs/domains/src/swap/domain/swap.error.message.ts
@@ -7,4 +7,5 @@ export enum SwapErrorMessage {
   SWAP_REPORT_NOT_FOUND = 'Swap report not found',
   COMMENT_SWAP_REPORT_REQUEST_FROM_NON_BUYER = 'Comment swap report request from non buyer',
   UNCOMMENTED_REPORT_EXISTS = 'Uncommented report exists',
+  FIND_REQUEST_FROM_UNAUTHORIZED_USER = 'Find request from unauthorized user',
 }

--- a/libs/domains/src/swap/domain/swap.error.message.ts
+++ b/libs/domains/src/swap/domain/swap.error.message.ts
@@ -6,4 +6,5 @@ export enum SwapErrorMessage {
   SWAP_BUMP_STUCK_ON_COOLDOWN = 'Swap bump stuck on cooldown',
   SWAP_REPORT_NOT_FOUND = 'Swap report not found',
   COMMENT_SWAP_REPORT_REQUEST_FROM_NON_BUYER = 'Comment swap report request from non buyer',
+  UNCOMMENTED_REPORT_EXISTS = 'Uncommented report exists',
 }


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
1. 거래글 삭제 전 상태 체크하기
2. find query에서 hidden filtering

## 어떻게 해결했나요?
1. 미답변 신고가 있는 거래글은 삭제 거부
2. hidden status는 본인 작성글만 보이도록 변경 - JwtAccessAllGuard, AutuUser로 얻은 userId를 query로 전달

기타 - 이용하지 않는 handler들을 resolver에서 삭제