### PR TITLE
feat: add authorId, reportedUserId in find report-previews where args

### DIFF
--- a/apps/api/src/api.module.ts
+++ b/apps/api/src/api.module.ts
@@ -19,6 +19,7 @@ import { CommonModule } from './app/common/common.module';
 import { ReportModule } from './app/report/report.module';
 import { CommentModule } from './app/comment/comment.module';
 import { VersionModule } from './app/version/version.module';
+import { SocialAccountModule } from './app/social-account/social-account.module';
 
 @Module({
   imports: [
@@ -42,6 +43,7 @@ import { VersionModule } from './app/version/version.module';
       },
     ]),
     AuthModule,
+    SocialAccountModule,
     CommonModule,
     UserModule,
     RoleModule,

--- a/apps/api/src/app/report/report.resolver.ts
+++ b/apps/api/src/app/report/report.resolver.ts
@@ -18,6 +18,9 @@ import { AllowlistRoleNames } from '@lib/domains/auth/decorators/allowlist-role-
 import { BlocklistRoleNames } from '@lib/domains/auth/decorators/blocklist-role-names/blocklist-role-names.decorator';
 import { ROOT_BLOCKLIST_ROLE_NAMES } from '@lib/domains/role/domain/role.types';
 import { RootRoleGuard } from '@lib/domains/auth/guards/role/root-role.guard';
+import { JwtAccessAllGuard } from '@lib/domains/auth/guards/jwt/jwt-access-all.guard';
+import { ExtractedJwtPayload } from '@lib/domains/auth/decorators/extracted-jwt-payload/extracted-jwt-payload.decorator';
+import { JwtPayload } from '@lib/shared/jwt/jwt.interfaces';
 import { GqlThrottlerBehindProxyGuard } from '../throttler/gql-throttler-behind-proxy.guard';
 
 @UseGuards(GqlThrottlerBehindProxyGuard)
@@ -34,9 +37,16 @@ export class ReportResolver {
     return this.queryBus.execute(query);
   }
 
+  @UseGuards(JwtAccessAllGuard)
   @Query(() => PaginatedReportPreviewsResponse)
-  async findReportPreviews(@Args() args: FindReportPreviewsArgs) {
-    const query = new FindReportPreviewsQuery(args);
+  async findReportPreviews(
+    @Args() args: FindReportPreviewsArgs,
+    @ExtractedJwtPayload() jwtPayload: JwtPayload,
+  ) {
+    const query = new FindReportPreviewsQuery({
+      args,
+      userId: jwtPayload.id,
+    });
     return this.queryBus.execute(query);
   }
 

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -135,6 +135,20 @@ input CreateSignedUrlInput {
   userId: String!
 }
 
+input CreateSocialAccountInput {
+  accessToken: String
+  expiresAt: Int
+  id: ID!
+  idToken: String
+  provider: String!
+  refreshToken: String
+  scope: String
+  sessionState: String
+  socialId: String!
+  tokenType: String
+  userId: String!
+}
+
 input CreateSwapInput {
   brandId: String
   businessFunction: String!
@@ -315,6 +329,7 @@ type Mutation {
   createReport(input: CreateReportInput!): String!
   createRole(input: CreateRoleInput!): String!
   createSignedUrl(input: CreateSignedUrlInput!): SignedUrlResponse!
+  createSocialAccount(input: CreateSocialAccountInput!): String!
   createSwap(input: CreateSwapInput!): String!
   createUser(input: CreateUserInput!): String!
   createUserImage(input: CreateUserImageInput!): String!
@@ -322,6 +337,8 @@ type Mutation {
   deleteGroup(id: ID!): String!
   deleteOffer(id: ID!, sellerId: ID!): String!
   deleteRole(id: ID!): String!
+  deleteSocialAccount(id: ID!): String!
+  deleteSocialAccountByProvider(provider: String!, socialId: String!): String!
   deleteSwap(id: ID!, proposerId: ID!): String!
   deleteUser(id: ID!): String!
   deleteUserImage(id: ID!): String!
@@ -334,6 +351,7 @@ type Mutation {
   updateGroup(input: UpdateGroupInput!): String!
   updateOffer(input: UpdateOfferInput!): OfferPreviewResponse!
   updateRole(input: UpdateRoleInput!): String!
+  updateSocialAccount(input: UpdateSocialAccountInput!): String!
   updateSwap(input: UpdateSwapInput!): SwapPreviewResponse!
   updateUser(input: UpdateUserInput!): String!
   updateUserImage(input: UpdateUserImageInput!): String!
@@ -491,6 +509,7 @@ type Query {
   findUsers(cursor: ID, skip: Int! = 1, take: Int!): PaginatedUsersResponse!
   findVersion(id: ID!): VersionResponse
   findVersionPreview(id: ID, refId: ID): VersionPreviewResponse
+  getSocialAccountsByUserId(id: ID!): String!
 }
 
 type ReportPreviewResponse {
@@ -692,6 +711,20 @@ input UpdateRoleInput {
   id: ID!
   name: String
   position: Int
+}
+
+input UpdateSocialAccountInput {
+  accessToken: String
+  expiresAt: Int
+  id: ID
+  idToken: String
+  provider: String
+  refreshToken: String
+  scope: String
+  sessionState: String
+  socialId: String
+  tokenType: String
+  userId: ID
 }
 
 input UpdateSwapInput {

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -518,7 +518,7 @@ type ReportPreviewResponse {
   id: ID!
   refId: ID!
   refVersionId: ID!
-  reportedUserId: ID!
+  reportedUserId: ID
   status: String!
   title: String!
   type: String!
@@ -537,7 +537,7 @@ type ReportResponse {
   id: ID!
   refId: ID!
   refVersionId: ID!
-  reportedUserId: ID!
+  reportedUserId: ID
   status: String!
   title: String!
   type: String!

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -518,6 +518,7 @@ type ReportPreviewResponse {
   id: ID!
   refId: ID!
   refVersionId: ID!
+  reportedUserId: ID!
   status: String!
   title: String!
   type: String!
@@ -536,6 +537,7 @@ type ReportResponse {
   id: ID!
   refId: ID!
   refVersionId: ID!
+  reportedUserId: ID!
   status: String!
   title: String!
   type: String!

--- a/libs/domains/src/group/application/queries/find-group-previews/find-group-previews.handler.ts
+++ b/libs/domains/src/group/application/queries/find-group-previews/find-group-previews.handler.ts
@@ -29,6 +29,7 @@ export class FindGroupPreviewsHandler extends PrismaQueryHandler<
           where: {
             status: OFFER_OPEN,
             isHidden: false,
+            deletedAt: null,
           },
           include: {
             seller: {
@@ -50,6 +51,7 @@ export class FindGroupPreviewsHandler extends PrismaQueryHandler<
           where: {
             status: DEMAND_OPEN,
             isHidden: false,
+            deletedAt: null,
           },
           include: {
             buyer: {

--- a/libs/domains/src/report/application/dtos/report-preview.response.ts
+++ b/libs/domains/src/report/application/dtos/report-preview.response.ts
@@ -20,8 +20,8 @@ export class ReportPreviewResponse {
   @Field(() => ID)
   refVersionId: string;
 
-  @Field(() => ID)
-  reportedUserId: string;
+  @Field(() => ID, { nullable: true })
+  reportedUserId?: string;
 
   @Field()
   status: string;

--- a/libs/domains/src/report/application/dtos/report-preview.response.ts
+++ b/libs/domains/src/report/application/dtos/report-preview.response.ts
@@ -20,6 +20,9 @@ export class ReportPreviewResponse {
   @Field(() => ID)
   refVersionId: string;
 
+  @Field(() => ID)
+  reportedUserId: string;
+
   @Field()
   status: string;
 

--- a/libs/domains/src/report/application/events/report-created/report-created.event.ts
+++ b/libs/domains/src/report/application/events/report-created/report-created.event.ts
@@ -6,14 +6,14 @@ export class ReportCreatedEvent implements IEvent {
 
   refId: string;
 
-  reportStatus: string;
-
   reportedUserId?: string;
+
+  reportStatus: string;
 
   constructor(input: ReportCreatedInput) {
     this.type = input.type;
     this.refId = input.refId;
-    this.reportStatus = input.reportStatus;
     this.reportedUserId = input.reportedUserId;
+    this.reportStatus = input.reportStatus;
   }
 }

--- a/libs/domains/src/report/application/events/report-created/report-created.input.ts
+++ b/libs/domains/src/report/application/events/report-created/report-created.input.ts
@@ -3,24 +3,24 @@ export class ReportCreatedInput {
 
   refId: string;
 
-  reportStatus: string;
-
   reportedUserId?: string;
+
+  reportStatus: string;
 
   constructor({
     type,
     refId,
-    reportStatus,
     reportedUserId,
+    reportStatus,
   }: {
     type: string;
     refId: string;
-    reportStatus: string;
     reportedUserId?: string;
+    reportStatus: string;
   }) {
     this.type = type;
     this.refId = refId;
-    this.reportStatus = reportStatus;
     this.reportedUserId = reportedUserId;
+    this.reportStatus = reportStatus;
   }
 }

--- a/libs/domains/src/report/application/queries/find-report-previews/find-report-previews-where.args.ts
+++ b/libs/domains/src/report/application/queries/find-report-previews/find-report-previews-where.args.ts
@@ -14,6 +14,10 @@ export class FindReportPreviewsWhereArgs {
 
   @IsOptional()
   @Field(() => ID, { nullable: true })
+  authorId?: string;
+
+  @IsOptional()
+  @Field(() => ID, { nullable: true })
   reportedUserId?: string;
 
   @IsOptional()

--- a/libs/domains/src/report/application/queries/find-report-previews/find-report-previews-where.args.ts
+++ b/libs/domains/src/report/application/queries/find-report-previews/find-report-previews-where.args.ts
@@ -13,6 +13,10 @@ export class FindReportPreviewsWhereArgs {
   refId?: string;
 
   @IsOptional()
+  @Field(() => ID, { nullable: true })
+  reportedUserId?: string;
+
+  @IsOptional()
   @Field(() => String, { nullable: true })
   status?: string;
 

--- a/libs/domains/src/report/application/queries/find-report-previews/find-report-previews.handler.ts
+++ b/libs/domains/src/report/application/queries/find-report-previews/find-report-previews.handler.ts
@@ -25,6 +25,7 @@ export class FindReportPreviewsHandler extends PrismaQueryHandler<
       where: {
         type: query.where?.type && query.where.refId ? query.where.type : undefined,
         refId: query.where?.type && query.where.refId ? query.where.refId : undefined,
+        reportedUserId: query.where?.reportedUserId,
         title: parseFollowedBySearcher(query.keyword),
         createdAt: query.where?.createdAt
           ? {

--- a/libs/domains/src/report/application/queries/find-report-previews/find-report-previews.handler.ts
+++ b/libs/domains/src/report/application/queries/find-report-previews/find-report-previews.handler.ts
@@ -26,6 +26,7 @@ export class FindReportPreviewsHandler extends PrismaQueryHandler<
         type: query.where?.type && query.where.refId ? query.where.type : undefined,
         refId: query.where?.type && query.where.refId ? query.where.refId : undefined,
         reportedUserId: query.where?.reportedUserId,
+        authorId: query.where?.authorId,
         title: parseFollowedBySearcher(query.keyword),
         createdAt: query.where?.createdAt
           ? {
@@ -41,7 +42,6 @@ export class FindReportPreviewsHandler extends PrismaQueryHandler<
           createdAt: query.orderBy?.createdAt,
         },
       ],
-      distinct: query.distinct ? ['title', 'authorId'] : undefined,
     });
 
     return paginate<ReportPreviewResponse>(this.parseResponses(reports), 'id', query.take);

--- a/libs/domains/src/report/application/queries/find-report-previews/find-report-previews.handler.ts
+++ b/libs/domains/src/report/application/queries/find-report-previews/find-report-previews.handler.ts
@@ -2,6 +2,8 @@ import { QueryHandler } from '@nestjs/cqrs';
 import { PrismaQueryHandler } from '@lib/shared/cqrs/queries/handlers/prisma-query.handler';
 import { paginate } from '@lib/shared/cqrs/queries/pagination/paginate';
 import { parseFollowedBySearcher } from '@lib/shared/search/search';
+import { ForbiddenException } from '@nestjs/common';
+import { ReportErrorMessage } from '@lib/domains/report/domain/report.error.message';
 import { FindReportPreviewsQuery } from './find-report-previews.query';
 import { PaginatedReportPreviewsResponse } from './paginated-report-previews.response';
 import { ReportPreviewResponse } from '../../dtos/report-preview.response';
@@ -16,6 +18,9 @@ export class FindReportPreviewsHandler extends PrismaQueryHandler<
   }
 
   async execute(query: FindReportPreviewsQuery): Promise<PaginatedReportPreviewsResponse> {
+    if (!!query.where?.authorId && query.where.authorId !== query.userId)
+      throw new ForbiddenException(ReportErrorMessage.FIND_REPORTS_REQUEST_FROM_UNAUTHORIZED_USER);
+
     const cursor = query.cursor
       ? {
           id: query.cursor,

--- a/libs/domains/src/report/application/queries/find-report-previews/find-report-previews.query.ts
+++ b/libs/domains/src/report/application/queries/find-report-previews/find-report-previews.query.ts
@@ -12,11 +12,14 @@ export class FindReportPreviewsQuery extends PaginationQuery {
 
   distinct?: boolean;
 
-  constructor(findReportsArgs: FindReportPreviewsArgs) {
-    super(findReportsArgs);
-    this.where = findReportsArgs.where;
-    this.orderBy = findReportsArgs.orderBy;
-    this.keyword = findReportsArgs.keyword;
-    this.distinct = findReportsArgs.distinct;
+  userId?: string;
+
+  constructor({ args, userId }: { args: FindReportPreviewsArgs; userId?: string }) {
+    super(args);
+    this.where = args.where;
+    this.orderBy = args.orderBy;
+    this.keyword = args.keyword;
+    this.distinct = args.distinct;
+    this.userId = userId;
   }
 }

--- a/libs/domains/src/report/domain/report.entity.ts
+++ b/libs/domains/src/report/domain/report.entity.ts
@@ -22,11 +22,11 @@ export class ReportEntity extends AggregateRoot {
 
   refVersion: VersionEntity;
 
-  status: string;
-
   authorId: string;
 
   reportedUserId?: string;
+
+  status: string;
 
   title: string;
 

--- a/libs/domains/src/report/domain/report.error.message.ts
+++ b/libs/domains/src/report/domain/report.error.message.ts
@@ -4,4 +4,5 @@ export enum ReportErrorMessage {
   REPORT_DELETE_COMMAND_FROM_UNAUTHORIZED_USER = 'Report delete command from unauthorized user',
   FAILED_TO_FIND_REF_ID_OF_REPORT = 'Failed to find refId of report',
   COMMENT_REPORT_REQUEST_FROM_UNAUTHORIZED_USER = 'Comment report request from unauthorized user',
+  FIND_REPORTS_REQUEST_FROM_UNAUTHORIZED_USER = 'Find reports request from unauthorized user',
 }


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
reports를 authorId, reportedUserId로 필터하여 가져오기

## 어떻게 해결했나요?
1. where args에 authorId, reportedUserId 추가
2. authorId를 변수로 취할 경우, 인증된 유저의 userId와 일치하는 지 검증 - JwtAccessAllGuard, ExtractedJwtPayload