### PR TITLE
feat: remove unused resolver from providers, use guards in resolver

### DIFF
--- a/apps/api/src/app/group/group.resolver.ts
+++ b/apps/api/src/app/group/group.resolver.ts
@@ -1,11 +1,10 @@
-import { Args, ID, Mutation, Query, Resolver } from '@nestjs/graphql';
+import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { GroupResponse } from '@lib/domains/group/application/dtos/group.response';
 import { CreateGroupInput } from '@lib/domains/group/application/commands/create-group/create-group.input';
 import { CreateGroupCommand } from '@lib/domains/group/application/commands/create-group/create-group.command';
 import { UpdateGroupInput } from '@lib/domains/group/application/commands/update-group/update-group.input';
 import { UpdateGroupCommand } from '@lib/domains/group/application/commands/update-group/update-group.command';
-import { DeleteGroupCommand } from '@lib/domains/group/application/commands/delete-group/delete-group.command';
 import { FindGroupsQuery } from '@lib/domains/group/application/queries/find-groups/find-groups.query';
 import { PaginatedGroupsResponse } from '@lib/domains/group/application/queries/find-groups/paginated-groups.response';
 import { FindGroupsArgs } from '@lib/domains/group/application/queries/find-groups/find-groups.args';
@@ -17,6 +16,11 @@ import { PaginatedGroupProfilesResponse } from '@lib/domains/group/application/q
 import { FindGroupProfilesArgs } from '@lib/domains/group/application/queries/find-group-profiles/find-group-profiles.args';
 import { FindGroupProfilesQuery } from '@lib/domains/group/application/queries/find-group-profiles/find-group-profiles.query';
 import { UseGuards } from '@nestjs/common';
+import { RootRoleGuard } from '@lib/domains/auth/guards/role/root-role.guard';
+import { BlocklistRoleNames } from '@lib/domains/auth/decorators/blocklist-role-names/blocklist-role-names.decorator';
+import { AllowlistRoleNames } from '@lib/domains/auth/decorators/allowlist-role-names/allowlist-role-names.decorator';
+import { JwtAccessAuthGuard } from '@lib/domains/auth/guards/jwt/jwt-access-auth.guard';
+import { ADMIN_ROLE_NAME } from '@lib/domains/role/domain/role.constants';
 import { GqlThrottlerBehindProxyGuard } from '../throttler/gql-throttler-behind-proxy.guard';
 
 @UseGuards(GqlThrottlerBehindProxyGuard)
@@ -53,21 +57,24 @@ export class GroupResolver {
     return this.queryBus.execute(query);
   }
 
+  @BlocklistRoleNames([])
+  @AllowlistRoleNames([ADMIN_ROLE_NAME])
+  @UseGuards(JwtAccessAuthGuard, RootRoleGuard)
   @Mutation(() => String)
   async createGroup(@Args('input') input: CreateGroupInput): Promise<string> {
     await this.commandBus.execute(new CreateGroupCommand(input));
     return input.id;
   }
 
+  @BlocklistRoleNames([])
+  @AllowlistRoleNames([ADMIN_ROLE_NAME])
+  @UseGuards(JwtAccessAuthGuard, RootRoleGuard)
   @Mutation(() => String)
   async updateGroup(@Args('input') input: UpdateGroupInput): Promise<string> {
     await this.commandBus.execute(new UpdateGroupCommand(input));
     return input.id;
   }
 
-  @Mutation(() => String)
-  async deleteGroup(@Args('id', { type: () => ID }) id: string): Promise<string> {
-    await this.commandBus.execute(new DeleteGroupCommand(id));
-    return id;
-  }
+  // NOTE
+  // careful deleteGroup
 }

--- a/apps/api/src/app/member/member.module.ts
+++ b/apps/api/src/app/member/member.module.ts
@@ -2,10 +2,10 @@ import { Module } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
 import { PrismaModule } from '@lib/shared/prisma/prisma.module';
 import { MEMBER_PROVIDERS } from '@lib/domains/member/member.providers';
-import { MemberResolver } from './member.resolver';
 
 @Module({
   imports: [CqrsModule, PrismaModule],
-  providers: [MemberResolver, ...MEMBER_PROVIDERS],
+  // No MemberResolver
+  providers: [...MEMBER_PROVIDERS],
 })
 export class MemberModule {}

--- a/apps/api/src/app/role/role.resolver.ts
+++ b/apps/api/src/app/role/role.resolver.ts
@@ -8,6 +8,11 @@ import { UpdateRoleInput } from '@lib/domains/role/application/commands/update-r
 import { UpdateRoleCommand } from '@lib/domains/role/application/commands/update-role/update-role.command';
 import { DeleteRoleCommand } from '@lib/domains/role/application/commands/delete-role/delete-role.command';
 import { UseGuards } from '@nestjs/common';
+import { BlocklistRoleNames } from '@lib/domains/auth/decorators/blocklist-role-names/blocklist-role-names.decorator';
+import { AllowlistRoleNames } from '@lib/domains/auth/decorators/allowlist-role-names/allowlist-role-names.decorator';
+import { JwtAccessAuthGuard } from '@lib/domains/auth/guards/jwt/jwt-access-auth.guard';
+import { RootRoleGuard } from '@lib/domains/auth/guards/role/root-role.guard';
+import { ADMIN_ROLE_NAME } from '@lib/domains/role/domain/role.constants';
 import { GqlThrottlerBehindProxyGuard } from '../throttler/gql-throttler-behind-proxy.guard';
 
 @UseGuards(GqlThrottlerBehindProxyGuard)
@@ -24,18 +29,27 @@ export class RoleResolver {
     return this.queryBus.execute(query);
   }
 
+  @BlocklistRoleNames([])
+  @AllowlistRoleNames([ADMIN_ROLE_NAME])
+  @UseGuards(JwtAccessAuthGuard, RootRoleGuard)
   @Mutation(() => String)
   async createRole(@Args('input') input: CreateRoleInput): Promise<string> {
     await this.commandBus.execute(new CreateRoleCommand(input));
     return input.id;
   }
 
+  @BlocklistRoleNames([])
+  @AllowlistRoleNames([ADMIN_ROLE_NAME])
+  @UseGuards(JwtAccessAuthGuard, RootRoleGuard)
   @Mutation(() => String)
   async updateRole(@Args('input') input: UpdateRoleInput): Promise<string> {
     await this.commandBus.execute(new UpdateRoleCommand(input));
     return input.id;
   }
 
+  @BlocklistRoleNames([])
+  @AllowlistRoleNames([ADMIN_ROLE_NAME])
+  @UseGuards(JwtAccessAuthGuard, RootRoleGuard)
   @Mutation(() => String)
   async deleteRole(@Args('id', { type: () => ID }) id: string): Promise<string> {
     await this.commandBus.execute(new DeleteRoleCommand(id));

--- a/apps/api/src/app/social-account/social-account.module.ts
+++ b/apps/api/src/app/social-account/social-account.module.ts
@@ -2,10 +2,10 @@ import { Module } from '@nestjs/common';
 import { CqrsModule } from '@nestjs/cqrs';
 import { PrismaModule } from '@lib/shared/prisma/prisma.module';
 import { SOCIAL_ACCOUNT_PROVIDERS } from '@lib/domains/social-account/social-account.providers';
-import { SocialAccountResolver } from './social-account.resolver';
 
 @Module({
   imports: [CqrsModule, PrismaModule],
-  providers: [SocialAccountResolver, ...SOCIAL_ACCOUNT_PROVIDERS],
+  // No SocialAccountResolver
+  providers: [...SOCIAL_ACCOUNT_PROVIDERS],
 })
 export class SocialAccountModule {}

--- a/apps/api/src/app/user-image/user-image.resolver.ts
+++ b/apps/api/src/app/user-image/user-image.resolver.ts
@@ -15,6 +15,7 @@ import { Args, ID, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { CreateSignedUrlInput } from '@lib/domains/user-image/application/commands/create-signed-url/create-signed-url.input';
 import { CreateSignedUrlCommand } from '@lib/domains/user-image/application/commands/create-signed-url/create-signed-url.command';
 import { SignedUrlResponse } from '@lib/shared/image/image.response';
+import { JwtAccessAuthGuard } from '@lib/domains/auth/guards/jwt/jwt-access-auth.guard';
 import { GqlThrottlerBehindProxyGuard } from '../throttler/gql-throttler-behind-proxy.guard';
 
 @UseGuards(GqlThrottlerBehindProxyGuard)
@@ -39,29 +40,34 @@ export class UserImageResolver {
     return this.queryBus.execute(query);
   }
 
+  @UseGuards(JwtAccessAuthGuard)
   @Mutation(() => String)
   async createUserImage(@Args('input') input: CreateUserImageInput): Promise<string> {
     await this.commandBus.execute(new CreateUserImageCommand(input));
     return input.id;
   }
 
+  @UseGuards(JwtAccessAuthGuard)
   @Mutation(() => String)
   async createManyUserImage(@Args('input') input: CreateManyUserImageInput): Promise<string> {
     await this.commandBus.execute(new CreateManyUserImageCommand(input));
     return '200';
   }
 
+  @UseGuards(JwtAccessAuthGuard)
   @Mutation(() => SignedUrlResponse)
   async createSignedUrl(@Args('input') input: CreateSignedUrlInput): Promise<SignedUrlResponse> {
     return this.commandBus.execute(new CreateSignedUrlCommand(input));
   }
 
+  @UseGuards(JwtAccessAuthGuard)
   @Mutation(() => String)
   async updateUserImage(@Args('input') input: UpdateUserImageInput): Promise<string> {
     await this.commandBus.execute(new UpdateUserImageCommand(input));
     return input.id;
   }
 
+  @UseGuards(JwtAccessAuthGuard)
   @Mutation(() => String)
   async deleteUserImage(@Args('id', { type: () => ID }) id: string): Promise<string> {
     await this.commandBus.execute(new DeleteUserImageCommand(id));

--- a/apps/api/src/app/user/user.resolver.ts
+++ b/apps/api/src/app/user/user.resolver.ts
@@ -1,10 +1,7 @@
-import { Args, ID, Mutation, Query, Resolver } from '@nestjs/graphql';
+import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
-import { CreateUserInput } from '@lib/domains/user/application/commands/create-user/create-user.input';
-import { CreateUserCommand } from '@lib/domains/user/application/commands/create-user/create-user.command';
 import { UpdateUserInput } from '@lib/domains/user/application/commands/update-user/update-user.input';
 import { UpdateUserCommand } from '@lib/domains/user/application/commands/update-user/update-user.command';
-import { DeleteUserCommand } from '@lib/domains/user/application/commands/delete-user/delete-user.command';
 import { MyUserResponse } from '@lib/domains/user/application/dtos/my-user.response';
 import { PaginationArgs } from '@lib/shared/cqrs/queries/pagination/pagination.args';
 import { FindUsersQuery } from '@lib/domains/user/application/queries/find-users/find-users.query';
@@ -64,22 +61,16 @@ export class UserResolver {
     return this.queryBus.execute(query);
   }
 
-  @Mutation(() => String)
-  async createUser(@Args('input') input: CreateUserInput): Promise<string> {
-    await this.commandBus.execute(new CreateUserCommand(input));
-    return input.id;
-  }
+  // NOTE
+  // createUser -> signInUser
+
+  // TODO
+  // deleteUser
 
   @Mutation(() => String)
   async updateUser(@Args('input') input: UpdateUserInput): Promise<string> {
     await this.commandBus.execute(new UpdateUserCommand(input));
     return input.id;
-  }
-
-  @Mutation(() => String)
-  async deleteUser(@Args('id', { type: () => ID }) id: string): Promise<string> {
-    await this.commandBus.execute(new DeleteUserCommand(id));
-    return id;
   }
 
   @UseGuards(JwtAccessAuthGuard)

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -54,13 +54,6 @@ type CommentResponse {
   updatedAt: DateTime!
 }
 
-input ConnectRolesInput {
-  groupId: ID!
-  roleIds: [ID!]!
-  roleNames: [String!]!
-  userId: ID!
-}
-
 input CreateCommentInput {
   authorId: ID!
   content: String!
@@ -98,12 +91,6 @@ input CreateGroupInput {
 
 input CreateManyUserImageInput {
   data: [CreateUserImageInput!]!
-}
-
-input CreateMemberInput {
-  groupId: ID!
-  id: ID!
-  userId: ID!
 }
 
 input CreateOfferInput {
@@ -148,20 +135,6 @@ input CreateSignedUrlInput {
   userId: String!
 }
 
-input CreateSocialAccountInput {
-  accessToken: String
-  expiresAt: Int
-  id: ID!
-  idToken: String
-  provider: String!
-  refreshToken: String
-  scope: String
-  sessionState: String
-  socialId: String!
-  tokenType: String
-  userId: String!
-}
-
 input CreateSwapInput {
   brandId: String
   businessFunction: String!
@@ -195,14 +168,6 @@ input CreateUserImageInput {
   url: String!
   userId: ID!
   width: Int
-}
-
-input CreateUserInput {
-  avatarURL: String
-  id: String!
-  name: String
-  phoneNumber: String
-  username: String!
 }
 
 """
@@ -265,12 +230,6 @@ type DemandResponse {
   status: String!
   totalPrice: Int!
   updatedAt: DateTime!
-}
-
-input DisconnectRolesInput {
-  id: ID!
-  roleIds: [ID!]!
-  roleNames: [String!]!
 }
 
 type GroupPreviewResponse {
@@ -340,31 +299,21 @@ type Mutation {
   bumpOffer(input: BumpOfferInput!): OfferPreviewResponse!
   bumpSwap(input: BumpSwapInput!): SwapPreviewResponse!
   commentReport(input: CommentReportInput!): String!
-  connectRoles(input: ConnectRolesInput!): String!
   createComment(input: CreateCommentInput!): String!
   createDemand(input: CreateDemandInput!): String!
   createGroup(input: CreateGroupInput!): String!
   createManyUserImage(input: CreateManyUserImageInput!): String!
-  createMember(input: CreateMemberInput!): String!
   createOffer(input: CreateOfferInput!): String!
   createReport(input: CreateReportInput!): String!
   createRole(input: CreateRoleInput!): String!
   createSignedUrl(input: CreateSignedUrlInput!): SignedUrlResponse!
-  createSocialAccount(input: CreateSocialAccountInput!): String!
   createSwap(input: CreateSwapInput!): String!
-  createUser(input: CreateUserInput!): String!
   createUserImage(input: CreateUserImageInput!): String!
   deleteDemand(buyerId: ID!, id: ID!): String!
-  deleteGroup(id: ID!): String!
-  deleteMember(id: ID!, userId: ID!): String!
   deleteOffer(id: ID!, sellerId: ID!): String!
   deleteRole(id: ID!): String!
-  deleteSocialAccount(id: ID!): String!
-  deleteSocialAccountByProvider(provider: String!, socialId: String!): String!
   deleteSwap(id: ID!, proposerId: ID!): String!
-  deleteUser(id: ID!): String!
   deleteUserImage(id: ID!): String!
-  disconnectRoles(input: DisconnectRolesInput!): String!
   linkSocialProfile(input: LinkSocialProfileInput!): String!
   logout: SocialUserResponse!
   reGenerateTokens: JwtResponse!
@@ -372,10 +321,8 @@ type Mutation {
   updateComment(input: UpdateCommentInput!): CommentResponse!
   updateDemand(input: UpdateDemandInput!): DemandPreviewResponse!
   updateGroup(input: UpdateGroupInput!): String!
-  updateMember(input: UpdateMemberInput!): String!
   updateOffer(input: UpdateOfferInput!): OfferPreviewResponse!
   updateRole(input: UpdateRoleInput!): String!
-  updateSocialAccount(input: UpdateSocialAccountInput!): String!
   updateSwap(input: UpdateSwapInput!): SwapPreviewResponse!
   updateUser(input: UpdateUserInput!): String!
   updateUserImage(input: UpdateUserImageInput!): String!
@@ -518,7 +465,6 @@ type Query {
   findGroupPreviews: [GroupPreviewResponse!]!
   findGroupProfiles(cursor: ID, distinct: Boolean, keyword: String, skip: Int! = 1, take: Int!): PaginatedGroupProfilesResponse!
   findGroups(cursor: ID, skip: Int! = 1, take: Int!): PaginatedGroupsResponse!
-  findMember(groupId: ID!, userId: ID!): MemberWithRolesResponse
   findMyUser(id: ID, username: String): MyUserResponse
   findOffer(id: ID, slug: String): OfferResponse
   findOfferPreviews(cursor: ID, distinct: Boolean, keyword: String, orderBy: JSON, skip: Int! = 1, take: Int!, where: JSON): PaginatedOfferPreviewsResponse!
@@ -534,7 +480,6 @@ type Query {
   findUsers(cursor: ID, skip: Int! = 1, take: Int!): PaginatedUsersResponse!
   findVersion(id: ID!): VersionResponse
   findVersionPreview(id: ID, refId: ID): VersionPreviewResponse
-  getSocialAccountsByUserId(id: ID!): String!
 }
 
 type ReportPreviewResponse {
@@ -716,11 +661,6 @@ input UpdateGroupInput {
   slug: String
 }
 
-input UpdateMemberInput {
-  id: ID!
-  userId: ID!
-}
-
 input UpdateOfferInput {
   brandId: ID
   businessFunction: String
@@ -743,20 +683,6 @@ input UpdateRoleInput {
   id: ID!
   name: String
   position: Int
-}
-
-input UpdateSocialAccountInput {
-  accessToken: String
-  expiresAt: Int
-  id: ID
-  idToken: String
-  provider: String
-  refreshToken: String
-  scope: String
-  sessionState: String
-  socialId: String
-  tokenType: String
-  userId: ID
 }
 
 input UpdateSwapInput {

--- a/libs/domains/src/role/domain/role.constants.ts
+++ b/libs/domains/src/role/domain/role.constants.ts
@@ -1,3 +1,5 @@
 export const DEFAULT_ROLE_COLOR = '#7f838e';
 
 export const REPORTED_USER_ROLE_NAME = '피신고자';
+
+export const ADMIN_ROLE_NAME = '사파리의 서포터';


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
1. 서버 내부에서 쓰이는 query, command를 외부로 노출하지 않기
2. 중요 data의 mutation 접근을 관리자 역할로 제한

## 어떻게 해결했나요?
1-1. member, social-account resolver 를 providers에서 제외
1-2. resolver에서 주석 처리
2. ADMIN_ROLE_NAME을 통한 guard 설정
