### PR TITLE
feat: send webhook after deal post created

### DIFF
--- a/apps/api/src/api.module.ts
+++ b/apps/api/src/api.module.ts
@@ -22,6 +22,7 @@ import { VersionModule } from './app/version/version.module';
 import { SocialAccountModule } from './app/social-account/social-account.module';
 import { MemberModule } from './app/member/member.module';
 import { BumpModule } from './app/bump/bump.module';
+import { DiscordWebhookModule } from './app/discord-webhook/discord-webhook.module';
 
 @Module({
   imports: [
@@ -60,6 +61,7 @@ import { BumpModule } from './app/bump/bump.module';
     ReportModule,
     CommentModule,
     VersionModule,
+    DiscordWebhookModule,
   ],
 })
 export class ApiModule {}

--- a/apps/api/src/app/discord-webhook/discord-webhook.module.ts
+++ b/apps/api/src/app/discord-webhook/discord-webhook.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { CqrsModule } from '@nestjs/cqrs';
+import { DISCORD_WEBHOOK_PROVIDERS } from '@lib/domains/discord-webhook/discord-webhook.providers';
+
+@Module({
+  imports: [CqrsModule],
+  providers: [...DISCORD_WEBHOOK_PROVIDERS],
+})
+export class DiscordWebhookModule {}

--- a/apps/api/src/config/config.example.yaml
+++ b/apps/api/src/config/config.example.yaml
@@ -46,3 +46,6 @@ logger:
   pretty:
   level:
   stdout:
+discord:
+  webhook:
+    url:

--- a/libs/domains/src/demand/application/commands/create-demand/create-demand.handler.ts
+++ b/libs/domains/src/demand/application/commands/create-demand/create-demand.handler.ts
@@ -1,5 +1,5 @@
 import { CommandHandler, EventPublisher } from '@nestjs/cqrs';
-import { ForbiddenException, Inject } from '@nestjs/common';
+import { ForbiddenException, Inject, InternalServerErrorException } from '@nestjs/common';
 import { DemandEntity } from '@lib/domains/demand/domain/demand.entity';
 import { DemandErrorMessage } from '@lib/domains/demand/domain/demand.error.message';
 import { DAY_HOURS } from '@lib/domains/offer/domain/offer.constants';
@@ -8,11 +8,13 @@ import { DAILY_DEMAND_POSTING_LIMIT } from '@lib/domains/demand/domain/demand.co
 import { CreateDemandCommand } from './create-demand.command';
 import { DemandSavePort } from '../../ports/out/demand.save.port';
 import { DemandResponse } from '../../dtos/demand.response';
+import { DemandLoadPort } from '../../ports/out/demand.load.port';
 
 @CommandHandler(CreateDemandCommand)
 export class CreateDemandHandler extends PrismaCommandHandler<CreateDemandCommand, DemandResponse> {
   constructor(
     @Inject('DemandSavePort') private savePort: DemandSavePort,
+    @Inject('DemandLoadPort') private loadPort: DemandLoadPort,
     private readonly publisher: EventPublisher,
   ) {
     super(DemandResponse);
@@ -30,9 +32,12 @@ export class CreateDemandHandler extends PrismaCommandHandler<CreateDemandComman
     if (countDailyDemandPostingInSameCategory > DAILY_DEMAND_POSTING_LIMIT)
       throw new ForbiddenException(DemandErrorMessage.DAILY_DEMAND_POSTING_LIMIT_EXCEEDED);
 
-    const demand = this.publisher.mergeObjectContext(new DemandEntity(command));
+    await this.savePort.create(new DemandEntity(command));
+    let demand = await this.loadPort.findById(command.id);
+    if (!demand) throw new InternalServerErrorException(DemandErrorMessage.DEMAND_CREATION_FAILED);
+
+    demand = this.publisher.mergeObjectContext(demand);
     demand.create();
-    await this.savePort.create(demand);
     demand.commit();
   }
 }

--- a/libs/domains/src/demand/application/events/demand-created/demand-created.event.ts
+++ b/libs/domains/src/demand/application/events/demand-created/demand-created.event.ts
@@ -3,7 +3,41 @@ import { IEvent } from '@nestjs/cqrs';
 export class DemandCreatedEvent implements IEvent {
   id: string;
 
-  constructor(id: string) {
+  username: string;
+
+  avatarURL?: string;
+
+  name: string;
+
+  slug?: string;
+
+  price: number;
+
+  source: string;
+
+  constructor({
+    id,
+    username,
+    avatarURL,
+    name,
+    slug,
+    price,
+    source,
+  }: {
+    id: string;
+    username: string;
+    avatarURL?: string;
+    name: string;
+    slug?: string;
+    price: number;
+    source: string;
+  }) {
     this.id = id;
+    this.username = username;
+    this.avatarURL = avatarURL;
+    this.name = name;
+    this.slug = slug;
+    this.price = price;
+    this.source = source;
   }
 }

--- a/libs/domains/src/demand/domain/demand.entity.ts
+++ b/libs/domains/src/demand/domain/demand.entity.ts
@@ -22,6 +22,8 @@ export class DemandEntity extends AggregateRoot {
 
   name: string;
 
+  slug: string | null;
+
   description: string | null;
 
   price: number;
@@ -66,7 +68,17 @@ export class DemandEntity extends AggregateRoot {
   }
 
   create() {
-    this.apply(new DemandCreatedEvent(this.id));
+    this.apply(
+      new DemandCreatedEvent({
+        id: this.id,
+        username: this.buyer.username,
+        avatarURL: this.buyer.avatarURL || undefined,
+        name: this.name,
+        slug: this.slug || undefined,
+        price: this.price,
+        source: this.source,
+      }),
+    );
   }
 
   isCompatibleSource(source: string) {

--- a/libs/domains/src/demand/domain/demand.error.message.ts
+++ b/libs/domains/src/demand/domain/demand.error.message.ts
@@ -1,6 +1,7 @@
 export enum DemandErrorMessage {
   DEMAND_NOT_FOUND = 'Demand not found',
   DEMAND_CHANGES_FROM_INCOMPATIBLE_PLATFORMS = 'Demand changes from incompatible platforms',
+  DEMAND_CREATION_FAILED = 'Demand creation failed',
   DEMAND_CHANGES_FROM_UNAUTHORIZED_USER = 'Demand changes from unauthorized user',
   DEMAND_DELETE_COMMAND_FROM_UNAUTHORIZED_USER = 'Demand delete command from unauthorized user',
   DEMAND_BUMP_STUCK_ON_COOLDOWN = 'Demand bump stuck on cooldown',

--- a/libs/domains/src/discord-webhook/application/commands/discord-webhook.command.providers.ts
+++ b/libs/domains/src/discord-webhook/application/commands/discord-webhook.command.providers.ts
@@ -1,0 +1,3 @@
+import { SendDiscordWebhookHandler } from './send-discord-webhook/send-discord-webhook.handler';
+
+export const DISCORD_WEBHOOK_COMMAND_PROVIDERS = [SendDiscordWebhookHandler];

--- a/libs/domains/src/discord-webhook/application/commands/send-discord-webhook/send-discord-webhook.command.ts
+++ b/libs/domains/src/discord-webhook/application/commands/send-discord-webhook/send-discord-webhook.command.ts
@@ -1,0 +1,34 @@
+import { ICommand } from '@nestjs/cqrs/dist';
+import { ColorResolvable } from 'discord.js';
+
+export class SendDiscordWebhookCommand implements ICommand {
+  title: string;
+
+  color: ColorResolvable;
+
+  username: string;
+
+  avatarURL?: string;
+
+  url: string;
+
+  constructor({
+    title,
+    color,
+    username,
+    avatarURL,
+    url,
+  }: {
+    title: string;
+    color: ColorResolvable;
+    username: string;
+    avatarURL?: string;
+    url: string;
+  }) {
+    this.title = title;
+    this.color = color;
+    this.username = username;
+    this.avatarURL = avatarURL;
+    this.url = url;
+  }
+}

--- a/libs/domains/src/discord-webhook/application/commands/send-discord-webhook/send-discord-webhook.handler.ts
+++ b/libs/domains/src/discord-webhook/application/commands/send-discord-webhook/send-discord-webhook.handler.ts
@@ -1,0 +1,21 @@
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { DiscordWebhookService } from '@lib/shared/discord/discord-webhook.service';
+import { EmbedBuilder } from 'discord.js';
+import { SendDiscordWebhookCommand } from './send-discord-webhook.command';
+
+@CommandHandler(SendDiscordWebhookCommand)
+export class SendDiscordWebhookHandler implements ICommandHandler<SendDiscordWebhookCommand> {
+  constructor(private readonly discordWebhookClient: DiscordWebhookService) {}
+
+  async execute(command: SendDiscordWebhookCommand): Promise<void> {
+    const embed = new EmbedBuilder()
+      .setTitle(command.title)
+      .setColor(command.color)
+      .setAuthor({
+        name: command.username,
+        iconURL: command.avatarURL,
+      })
+      .setDescription(command.url);
+    await this.discordWebhookClient.sendWebhook({ embeds: [embed] });
+  }
+}

--- a/libs/domains/src/discord-webhook/application/sagas/discord-webhook.sagas.ts
+++ b/libs/domains/src/discord-webhook/application/sagas/discord-webhook.sagas.ts
@@ -3,6 +3,7 @@ import { ICommand, Saga, ofType } from '@nestjs/cqrs';
 import { Observable, filter, map } from 'rxjs';
 import { OfferCreatedEvent } from '@lib/domains/offer/application/events/offer-created/offer-created.event';
 import { ConfigService } from '@nestjs/config';
+import { DemandCreatedEvent } from '@lib/domains/demand/application/events/demand-created/demand-created.event';
 import { SendDiscordWebhookCommand } from '../commands/send-discord-webhook/send-discord-webhook.command';
 
 @Injectable()
@@ -22,6 +23,24 @@ export class DiscordWebhookSagas {
             username: event.username,
             avatarURL: event.avatarURL,
             title: `[팝니다] ${event.name} - ${event.price}`,
+            url: this.parseUrl({ username: event.username, type: 'offer', slug: event.slug! }),
+          }),
+      ),
+    );
+
+  @Saga()
+  demandCreated = (events$: Observable<any>): Observable<ICommand> =>
+    events$.pipe(
+      ofType(DemandCreatedEvent),
+      filter((event) => event.source === 'mobile' || event.source === 'browser'),
+      filter((event) => !!event.slug),
+      map(
+        (event) =>
+          new SendDiscordWebhookCommand({
+            color: 0x16a34a,
+            username: event.username,
+            avatarURL: event.avatarURL,
+            title: `[삽니다] ${event.name} - ${event.price}`,
             url: this.parseUrl({ username: event.username, type: 'offer', slug: event.slug! }),
           }),
       ),

--- a/libs/domains/src/discord-webhook/application/sagas/discord-webhook.sagas.ts
+++ b/libs/domains/src/discord-webhook/application/sagas/discord-webhook.sagas.ts
@@ -4,6 +4,7 @@ import { Observable, filter, map } from 'rxjs';
 import { OfferCreatedEvent } from '@lib/domains/offer/application/events/offer-created/offer-created.event';
 import { ConfigService } from '@nestjs/config';
 import { DemandCreatedEvent } from '@lib/domains/demand/application/events/demand-created/demand-created.event';
+import { SwapCreatedEvent } from '@lib/domains/swap/application/events/swap-created/swap-created.event';
 import { SendDiscordWebhookCommand } from '../commands/send-discord-webhook/send-discord-webhook.command';
 
 @Injectable()
@@ -41,6 +42,24 @@ export class DiscordWebhookSagas {
             username: event.username,
             avatarURL: event.avatarURL,
             title: `[삽니다] ${event.name} - ${event.price}`,
+            url: this.parseUrl({ username: event.username, type: 'offer', slug: event.slug! }),
+          }),
+      ),
+    );
+
+  @Saga()
+  swapCreated = (events$: Observable<any>): Observable<ICommand> =>
+    events$.pipe(
+      ofType(SwapCreatedEvent),
+      filter((event) => event.source === 'mobile' || event.source === 'browser'),
+      filter((event) => !!event.slug),
+      map(
+        (event) =>
+          new SendDiscordWebhookCommand({
+            color: 0x51329a,
+            username: event.username,
+            avatarURL: event.avatarURL,
+            title: `[교환합니다] ${event.name} ${event.price ? `+${event.price}` : ''}`,
             url: this.parseUrl({ username: event.username, type: 'offer', slug: event.slug! }),
           }),
       ),

--- a/libs/domains/src/discord-webhook/application/sagas/discord-webhook.sagas.ts
+++ b/libs/domains/src/discord-webhook/application/sagas/discord-webhook.sagas.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+import { ICommand, Saga, ofType } from '@nestjs/cqrs';
+import { Observable, filter, map } from 'rxjs';
+import { OfferCreatedEvent } from '@lib/domains/offer/application/events/offer-created/offer-created.event';
+import { ConfigService } from '@nestjs/config';
+import { SendDiscordWebhookCommand } from '../commands/send-discord-webhook/send-discord-webhook.command';
+
+@Injectable()
+export class DiscordWebhookSagas {
+  constructor(private readonly configService: ConfigService) {}
+
+  @Saga()
+  offerCreated = (events$: Observable<any>): Observable<ICommand> =>
+    events$.pipe(
+      ofType(OfferCreatedEvent),
+      filter((event) => event.source === 'mobile' || event.source === 'browser'),
+      filter((event) => !!event.slug),
+      map(
+        (event) =>
+          new SendDiscordWebhookCommand({
+            color: 0xc43176,
+            username: event.username,
+            avatarURL: event.avatarURL,
+            title: `[팝니다] ${event.name} - ${event.price}`,
+            url: this.parseUrl({ username: event.username, type: 'offer', slug: event.slug! }),
+          }),
+      ),
+    );
+
+  parseUrl({ username, type, slug }: { username: string; type: string; slug: string }) {
+    return `${this.configService.get('frontend.host')}/user/${username}/${type}/${slug}`;
+  }
+}

--- a/libs/domains/src/discord-webhook/discord-webhook.providers.ts
+++ b/libs/domains/src/discord-webhook/discord-webhook.providers.ts
@@ -1,0 +1,9 @@
+import { DiscordWebhookService } from '@lib/shared/discord/discord-webhook.service';
+import { DISCORD_WEBHOOK_COMMAND_PROVIDERS } from './application/commands/discord-webhook.command.providers';
+import { DiscordWebhookSagas } from './application/sagas/discord-webhook.sagas';
+
+export const DISCORD_WEBHOOK_PROVIDERS = [
+  ...DISCORD_WEBHOOK_COMMAND_PROVIDERS,
+  DiscordWebhookSagas,
+  DiscordWebhookService,
+];

--- a/libs/domains/src/offer/application/commands/create-offer/create-offer.handler.ts
+++ b/libs/domains/src/offer/application/commands/create-offer/create-offer.handler.ts
@@ -1,5 +1,5 @@
 import { CommandHandler, EventPublisher } from '@nestjs/cqrs';
-import { ForbiddenException, Inject } from '@nestjs/common';
+import { ForbiddenException, Inject, InternalServerErrorException } from '@nestjs/common';
 import { OfferEntity } from '@lib/domains/offer/domain/offer.entity';
 import { OfferErrorMessage } from '@lib/domains/offer/domain/offer.error.message';
 import { DAILY_OFFER_POSTING_LIMIT, DAY_HOURS } from '@lib/domains/offer/domain/offer.constants';
@@ -7,11 +7,13 @@ import { PrismaCommandHandler } from '@lib/shared/cqrs/commands/handlers/prisma-
 import { CreateOfferCommand } from './create-offer.command';
 import { OfferSavePort } from '../../ports/out/offer.save.port';
 import { OfferResponse } from '../../dtos/offer.response';
+import { OfferLoadPort } from '../../ports/out/offer.load.port';
 
 @CommandHandler(CreateOfferCommand)
 export class CreateOfferHandler extends PrismaCommandHandler<CreateOfferCommand, OfferResponse> {
   constructor(
     @Inject('OfferSavePort') private savePort: OfferSavePort,
+    @Inject('OfferLoadPort') private loadPort: OfferLoadPort,
     private readonly publisher: EventPublisher,
   ) {
     super(OfferResponse);
@@ -29,9 +31,12 @@ export class CreateOfferHandler extends PrismaCommandHandler<CreateOfferCommand,
     if (countDailyOfferPostingInSameCategory > DAILY_OFFER_POSTING_LIMIT)
       throw new ForbiddenException(OfferErrorMessage.DAILY_OFFER_POSTING_LIMIT_EXCEEDED);
 
-    const offer = this.publisher.mergeObjectContext(new OfferEntity(command));
+    await this.savePort.create(new OfferEntity(command));
+    let offer = await this.loadPort.findById(command.id);
+    if (!offer) throw new InternalServerErrorException(OfferErrorMessage.OFFER_CREATION_FAILED);
+
+    offer = this.publisher.mergeObjectContext(offer);
     offer.create();
-    await this.savePort.create(offer);
     offer.commit();
   }
 }

--- a/libs/domains/src/offer/application/events/offer-created/offer-created.event.ts
+++ b/libs/domains/src/offer/application/events/offer-created/offer-created.event.ts
@@ -3,7 +3,41 @@ import { IEvent } from '@nestjs/cqrs';
 export class OfferCreatedEvent implements IEvent {
   id: string;
 
-  constructor(id: string) {
+  username: string;
+
+  avatarURL?: string;
+
+  name: string;
+
+  slug?: string;
+
+  price: number;
+
+  source: string;
+
+  constructor({
+    id,
+    username,
+    avatarURL,
+    name,
+    slug,
+    price,
+    source,
+  }: {
+    id: string;
+    username: string;
+    avatarURL?: string;
+    name: string;
+    slug?: string;
+    price: number;
+    source: string;
+  }) {
     this.id = id;
+    this.username = username;
+    this.avatarURL = avatarURL;
+    this.name = name;
+    this.slug = slug;
+    this.price = price;
+    this.source = source;
   }
 }

--- a/libs/domains/src/offer/domain/offer.entity.ts
+++ b/libs/domains/src/offer/domain/offer.entity.ts
@@ -23,6 +23,8 @@ export class OfferEntity extends AggregateRoot {
 
   name: string;
 
+  slug: string | null;
+
   description: string | null;
 
   price: number;
@@ -68,7 +70,17 @@ export class OfferEntity extends AggregateRoot {
   }
 
   create() {
-    this.apply(new OfferCreatedEvent(this.id));
+    this.apply(
+      new OfferCreatedEvent({
+        id: this.id,
+        username: this.seller.username,
+        avatarURL: this.seller.avatarURL || undefined,
+        name: this.name,
+        slug: this.slug || undefined,
+        price: this.price,
+        source: this.source,
+      }),
+    );
   }
 
   isCompatibleSource(source: string) {

--- a/libs/domains/src/offer/domain/offer.error.message.ts
+++ b/libs/domains/src/offer/domain/offer.error.message.ts
@@ -1,6 +1,7 @@
 export enum OfferErrorMessage {
   OFFER_IS_NOT_FOUND = 'Offer is not found',
   OFFER_FROM_REPORTED_NOT_FOUND = 'Offer from reported not found',
+  OFFER_CREATION_FAILED = 'Offer creation failed',
   OFFER_CHANGES_FROM_INCOMPATIBLE_PLATFORMS = 'Offer changes from incompatible platforms',
   OFFER_CHANGES_FROM_UNAUTHORIZED_USER = 'Offer changes from unauthorized user',
   OFFER_DELETE_COMMAND_FROM_UNAUTHORIZED_USER = 'Offer delete command from unauthorized user',

--- a/libs/domains/src/swap/application/events/swap-created/swap-created.event.ts
+++ b/libs/domains/src/swap/application/events/swap-created/swap-created.event.ts
@@ -3,7 +3,41 @@ import { IEvent } from '@nestjs/cqrs';
 export class SwapCreatedEvent implements IEvent {
   id: string;
 
-  constructor(id: string) {
+  username: string;
+
+  avatarURL?: string;
+
+  name: string;
+
+  slug?: string;
+
+  price: number;
+
+  source: string;
+
+  constructor({
+    id,
+    username,
+    avatarURL,
+    name,
+    slug,
+    price,
+    source,
+  }: {
+    id: string;
+    username: string;
+    avatarURL?: string;
+    name: string;
+    slug?: string;
+    price: number;
+    source: string;
+  }) {
     this.id = id;
+    this.username = username;
+    this.avatarURL = avatarURL;
+    this.name = name;
+    this.slug = slug;
+    this.price = price;
+    this.source = source;
   }
 }

--- a/libs/domains/src/swap/domain/swap.entity.ts
+++ b/libs/domains/src/swap/domain/swap.entity.ts
@@ -34,6 +34,8 @@ export class SwapEntity extends AggregateRoot {
 
   name1: string;
 
+  slug: string | null;
+
   description0: string | null;
 
   description1: string | null;
@@ -70,7 +72,17 @@ export class SwapEntity extends AggregateRoot {
   }
 
   create() {
-    this.apply(new SwapCreatedEvent(this.id));
+    this.apply(
+      new SwapCreatedEvent({
+        id: this.id,
+        username: this.proposer.username,
+        avatarURL: this.proposer.avatarURL || undefined,
+        name: `${this.name0} <-> ${this.name1}`,
+        slug: this.slug || undefined,
+        price: this.price,
+        source: this.source,
+      }),
+    );
   }
 
   isCompatibleSource(source: string) {

--- a/libs/domains/src/swap/domain/swap.error.message.ts
+++ b/libs/domains/src/swap/domain/swap.error.message.ts
@@ -1,6 +1,7 @@
 export enum SwapErrorMessage {
   SWAP_NOT_FOUND = 'Swap not found',
   SWAP_CHANGES_FROM_INCOMPATIBLE_PLATFORMS = 'Swap changes from incompatible platforms',
+  SWAP_CREATION_FAILED = 'Swap creation failed',
   SWAP_CHANGES_FROM_UNAUTHORIZED_USER = 'Swap changes from unauthorized user',
   SWAP_DELETE_COMMAND_FROM_UNAUTHORIZED_USER = 'Swap delete command from unauthorized user',
   SWAP_BUMP_STUCK_ON_COOLDOWN = 'Swap bump stuck on cooldown',

--- a/libs/shared/package.json
+++ b/libs/shared/package.json
@@ -31,6 +31,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "dayjs": "^1.11.10",
+    "discord.js": "^14.14.1",
     "express": "^4.18.2",
     "fs": "^0.0.1-security",
     "graphql": "^16.8.0",

--- a/libs/shared/src/discord/discord-webhook.service.ts
+++ b/libs/shared/src/discord/discord-webhook.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { EmbedBuilder, WebhookClient } from 'discord.js';
+
+@Injectable()
+export class DiscordWebhookService {
+  private readonly webhook: WebhookClient;
+
+  constructor(private readonly configService: ConfigService) {
+    this.webhook = new WebhookClient({
+      url: this.configService.get('discord.webhook.url')!,
+    });
+  }
+
+  async sendWebhook({ embeds }: { embeds: EmbedBuilder[] }) {
+    return this.webhook.send({
+      embeds,
+    });
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1461,10 +1461,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@discordjs/collection@npm:^1.5.3":
+"@discordjs/builders@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "@discordjs/builders@npm:1.7.0"
+  dependencies:
+    "@discordjs/formatters": ^0.3.3
+    "@discordjs/util": ^1.0.2
+    "@sapphire/shapeshift": ^3.9.3
+    discord-api-types: 0.37.61
+    fast-deep-equal: ^3.1.3
+    ts-mixer: ^6.0.3
+    tslib: ^2.6.2
+  checksum: 837e7643fc8396e4914bbbfbbfa1232ab7109c931884e8df45cd7356944633590f710a18513d30a10de1b6686ed5166df702bde0c4511fb0cbcac897edd9e56a
+  languageName: node
+  linkType: hard
+
+"@discordjs/collection@npm:1.5.3, @discordjs/collection@npm:^1.5.3":
   version: 1.5.3
   resolution: "@discordjs/collection@npm:1.5.3"
   checksum: fefed19bea0f69053d195f9d9dc8af07ca5d8c9b1064581e0aa14bda2b70e632b93c164d5ef3e4910f5442369612ff4eec8d52a700aec562510c19b223f67023
+  languageName: node
+  linkType: hard
+
+"@discordjs/collection@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@discordjs/collection@npm:2.0.0"
+  checksum: c2d05fa2b9a27bb64e93e2836bbe44c835d21f85e28cd934f6e2a81fef423ab0415968cca9d066b83347539edc8ea9afa8075d80bd62594e39f09eb881052c49
   languageName: node
   linkType: hard
 
@@ -1474,6 +1496,15 @@ __metadata:
   dependencies:
     discord-api-types: 0.37.50
   checksum: 653c88595fc6c25c1beedcd88b05a3f1241fef69844cc96e45f2cd34fea9ff07892c7f3b57edb4008ad59f7e62bca1b7b35400c6200b07ed42eef7189672d509
+  languageName: node
+  linkType: hard
+
+"@discordjs/formatters@npm:^0.3.3":
+  version: 0.3.3
+  resolution: "@discordjs/formatters@npm:0.3.3"
+  dependencies:
+    discord-api-types: 0.37.61
+  checksum: a844628094a6effa8ac4e4a4ea9082d5c89e6cae6bbd18e60abd410769e5ea18f64aa2db8623aa3c8c572084368f6c2e27cc2d72af640aff5e4ee7fc42132c60
   languageName: node
   linkType: hard
 
@@ -1494,10 +1525,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@discordjs/rest@npm:^2.1.0":
+  version: 2.2.0
+  resolution: "@discordjs/rest@npm:2.2.0"
+  dependencies:
+    "@discordjs/collection": ^2.0.0
+    "@discordjs/util": ^1.0.2
+    "@sapphire/async-queue": ^1.5.0
+    "@sapphire/snowflake": ^3.5.1
+    "@vladfrangu/async_event_emitter": ^2.2.2
+    discord-api-types: 0.37.61
+    magic-bytes.js: ^1.5.0
+    tslib: ^2.6.2
+    undici: 5.27.2
+  checksum: 29a14ecf3282ae3306883f1f6c870693d0ecacd080c5b66a72e31487a8070655807a80a8bf09bebea4f73e631439abc5121dfa38016ca0ccbe3f68c0f7ffc80e
+  languageName: node
+  linkType: hard
+
 "@discordjs/util@npm:^1.0.1":
   version: 1.0.1
   resolution: "@discordjs/util@npm:1.0.1"
   checksum: b55d5284cd8306b0e77a303c41fa99dcc650babaf9ef2f02ea38b1f8ecc7218a7694128714343379dbf6b2a402a0851e00862c0d974ad07b8e980722f5139d73
+  languageName: node
+  linkType: hard
+
+"@discordjs/util@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@discordjs/util@npm:1.0.2"
+  checksum: 320d7e125981001160d413ae56e76e60447dce102010b80e3b1b16d885be765df5ae2551aa79fdc4d435a82361ed72246b44251f0c1f7a8fef7056a4481d5609
   languageName: node
   linkType: hard
 
@@ -1515,6 +1570,23 @@ __metadata:
     tslib: ^2.6.1
     ws: ^8.13.0
   checksum: d34f17646606dbac82989c3aa3fddd1e2a23da532b96f1fc130a0ddb6735079523f09a70b560b315f3e6634b6336accc48680539e4c62cf34826d79c6304778a
+  languageName: node
+  linkType: hard
+
+"@discordjs/ws@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@discordjs/ws@npm:1.0.2"
+  dependencies:
+    "@discordjs/collection": ^2.0.0
+    "@discordjs/rest": ^2.1.0
+    "@discordjs/util": ^1.0.2
+    "@sapphire/async-queue": ^1.5.0
+    "@types/ws": ^8.5.9
+    "@vladfrangu/async_event_emitter": ^2.2.2
+    discord-api-types: 0.37.61
+    tslib: ^2.6.2
+    ws: ^8.14.2
+  checksum: 2564d3ff00d04d7638955c8c9a9f6234c50168fbe8243140bc458dc9ffa39ad5063e7d5762cdce71bb8bcf70b6353c28b8531e40f54568706898e92bc8748590
   languageName: node
   linkType: hard
 
@@ -1557,6 +1629,13 @@ __metadata:
   version: 8.50.0
   resolution: "@eslint/js@npm:8.50.0"
   checksum: 302478f2acaaa7228729ec6a04f56641590185e1d8cd1c836a6db8a6b8009f80a57349341be9fbb9aa1721a7a569d1be3ffc598a33300d22816f11832095386c
+  languageName: node
+  linkType: hard
+
+"@fastify/busboy@npm:^2.0.0":
+  version: 2.1.1
+  resolution: "@fastify/busboy@npm:2.1.1"
+  checksum: 42c32ef75e906c9a4809c1e1930a5ca6d4ddc8d138e1a8c8ba5ea07f997db32210617d23b2e4a85fe376316a41a1a0439fc6ff2dedf5126d96f45a9d80754fb2
   languageName: node
   linkType: hard
 
@@ -1702,6 +1781,7 @@ __metadata:
     class-transformer: ^0.5.1
     class-validator: ^0.14.0
     dayjs: ^1.11.10
+    discord.js: ^14.14.1
     express: ^4.18.2
     fs: ^0.0.1-security
     graphql: ^16.8.0
@@ -3036,7 +3116,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sapphire/snowflake@npm:^3.5.1":
+"@sapphire/shapeshift@npm:^3.9.3":
+  version: 3.9.7
+  resolution: "@sapphire/shapeshift@npm:3.9.7"
+  dependencies:
+    fast-deep-equal: ^3.1.3
+    lodash: ^4.17.21
+  checksum: a36032ff8fc54056ea21e0cdbbea84c3d80c0c0fb19b2685e14e29111ab9c1172c9273e1e54d49e2a62ba5a393f18b3dab9330d34b97d3519d572e32dd64913d
+  languageName: node
+  linkType: hard
+
+"@sapphire/snowflake@npm:3.5.1, @sapphire/snowflake@npm:^3.5.1":
   version: 3.5.1
   resolution: "@sapphire/snowflake@npm:3.5.1"
   checksum: 8fc025020adab1a7a1a5d2cf07704d598cc1977b50e5fcd3a5dd239f00934dc936d3a4d5ae336e71d8bf1d88ec27aa814b34de79e38ff097b7b9ba5a7977a683
@@ -4160,12 +4250,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/ws@npm:8.5.9":
+  version: 8.5.9
+  resolution: "@types/ws@npm:8.5.9"
+  dependencies:
+    "@types/node": "*"
+  checksum: 83f436b731d2cdc49a45ced31a0a65cdd2e39c24d7b882776c26efa190dad6553e266d624c7a7089f36ad3ed471e02e729f3219282c80689b435f665df4a2b0b
+  languageName: node
+  linkType: hard
+
 "@types/ws@npm:^8.5.5":
   version: 8.5.5
   resolution: "@types/ws@npm:8.5.5"
   dependencies:
     "@types/node": "*"
   checksum: d00bf8070e6938e3ccf933010921c6ce78ac3606696ce37a393b27a9a603f7bd93ea64f3c5fa295a2f743575ba9c9a9fdb904af0f5fe2229bf2adf0630386e4a
+  languageName: node
+  linkType: hard
+
+"@types/ws@npm:^8.5.9":
+  version: 8.5.10
+  resolution: "@types/ws@npm:8.5.10"
+  dependencies:
+    "@types/node": "*"
+  checksum: 3ec416ea2be24042ebd677932a462cf16d2080393d8d7d0b1b3f5d6eaa4a7387aaf0eefb99193c0bfd29444857cf2e0c3ac89899e130550dc6c14ada8a46d25e
   languageName: node
   linkType: hard
 
@@ -6463,6 +6571,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"discord-api-types@npm:0.37.61":
+  version: 0.37.61
+  resolution: "discord-api-types@npm:0.37.61"
+  checksum: fe33d528e31a6de0bab2afb43d0e058957a6da6cfc4d797943fac83aeb8d07543dc0f85cad3c4e6789cbbac0c7ca49dae5ac465224b129c7acb716097fa0b081
+  languageName: node
+  linkType: hard
+
 "discord.js@npm:^14.13.0":
   version: 14.13.0
   resolution: "discord.js@npm:14.13.0"
@@ -6482,6 +6597,28 @@ __metadata:
     undici: 5.22.1
     ws: ^8.13.0
   checksum: c273645ac2f92a5052914261c40d04f7fbf81f8d2542f7f0ec9b2e5f9006ff7436d7c6254db924a12826b7f3b49cbfdd577807a0a4ed396036e106f39701a167
+  languageName: node
+  linkType: hard
+
+"discord.js@npm:^14.14.1":
+  version: 14.14.1
+  resolution: "discord.js@npm:14.14.1"
+  dependencies:
+    "@discordjs/builders": ^1.7.0
+    "@discordjs/collection": 1.5.3
+    "@discordjs/formatters": ^0.3.3
+    "@discordjs/rest": ^2.1.0
+    "@discordjs/util": ^1.0.2
+    "@discordjs/ws": ^1.0.2
+    "@sapphire/snowflake": 3.5.1
+    "@types/ws": 8.5.9
+    discord-api-types: 0.37.61
+    fast-deep-equal: 3.1.3
+    lodash.snakecase: 4.1.1
+    tslib: 2.6.2
+    undici: 5.27.2
+    ws: 8.14.2
+  checksum: 651e61861ae33e6ec3903e72a8bf229caae5dab73f8d409c3673430cafd9c438a0dd59983242bdcff47bab50da39f7a04da5b586c35b396c102e8e87637076e5
   languageName: node
   linkType: hard
 
@@ -7276,7 +7413,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-deep-equal@npm:^3.1.1, fast-deep-equal@npm:^3.1.3":
+"fast-deep-equal@npm:3.1.3, fast-deep-equal@npm:^3.1.1, fast-deep-equal@npm:^3.1.3":
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
   checksum: e21a9d8d84f53493b6aa15efc9cfd53dd5b714a1f23f67fb5dc8f574af80df889b3bce25dc081887c6d25457cce704e636395333abad896ccdec03abaf1f3f9d
@@ -9856,7 +9993,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.snakecase@npm:^4.1.1":
+"lodash.snakecase@npm:4.1.1, lodash.snakecase@npm:^4.1.1":
   version: 4.1.1
   resolution: "lodash.snakecase@npm:4.1.1"
   checksum: 1685ed3e83dda6eae5a4dcaee161a51cd210aabb3e1c09c57150e7dd8feda19e4ca0d27d0631eabe8d0f4eaa51e376da64e8c018ae5415417c5890d42feb72a8
@@ -9967,6 +10104,13 @@ __metadata:
   version: 1.0.17
   resolution: "magic-bytes.js@npm:1.0.17"
   checksum: 8afda0fee0f834a77304ca8e32e49acde4e0a03c0bee6a629959ae78c8dbf7e007e29395cefadd7205635b52bf4e9575b7c94ef015795b7d720814930723c0db
+  languageName: node
+  linkType: hard
+
+"magic-bytes.js@npm:^1.5.0":
+  version: 1.10.0
+  resolution: "magic-bytes.js@npm:1.10.0"
+  checksum: c10e7fc3fe584e4b0767554fb6a12dfc4a9db0782d5005cbdd46bc9b36a8bb420f5266a4b02e089ea4db587937fde289ea467a7a379ad969fb906bf4a0ec3f38
   languageName: node
   linkType: hard
 
@@ -13180,7 +13324,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:2.6.2, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.6.1":
+"tslib@npm:2.6.2, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.6.1, tslib@npm:^2.6.2":
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: 329ea56123005922f39642318e3d1f0f8265d1e7fcb92c633e0809521da75eeaca28d2cf96d7248229deb40e5c19adf408259f4b9640afd20d13aecc1430f3ad
@@ -13423,12 +13567,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^5.21.0":
-  version: 5.28.3
-  resolution: "undici@npm:5.28.3"
+"undici@npm:5.22.1":
+  version: 5.22.1
+  resolution: "undici@npm:5.22.1"
+  dependencies:
+    busboy: ^1.6.0
+  checksum: 048a3365f622be44fb319316cedfaa241c59cf7f3368ae7667a12323447e1822e8cc3d00f6956c852d1478a6fde1cbbe753f49e05f2fdaed229693e716ebaf35
+  languageName: node
+  linkType: hard
+
+"undici@npm:5.27.2":
+  version: 5.27.2
+  resolution: "undici@npm:5.27.2"
   dependencies:
     "@fastify/busboy": ^2.0.0
-  checksum: fa1e65aff896c5e2ee23637b632e306f9e3a2b32a3dc0b23ea71e5555ad350bcc25713aea894b3dccc0b7dc2c5e92a5a58435ebc2033b731a5524506f573dfd2
+  checksum: 22bbdd763798700979986546d70072b67223189353d2a811efa9c6e44476161a0d1781ffe24115221f69a1b344b95d5926bd39a6eb760a2cd8804781cec0c5eb
   languageName: node
   linkType: hard
 
@@ -13932,6 +14085,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ws@npm:8.14.2":
+  version: 8.14.2
+  resolution: "ws@npm:8.14.2"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 3ca0dad26e8cc6515ff392b622a1467430814c463b3368b0258e33696b1d4bed7510bc7030f7b72838b9fdeb8dbd8839cbf808367d6aae2e1d668ce741d4308b
+  languageName: node
+  linkType: hard
+
 "ws@npm:^5.2.0 || ^6.0.0 || ^7.0.0, ws@npm:^7.0.0":
   version: 7.5.9
   resolution: "ws@npm:7.5.9"
@@ -13944,6 +14112,21 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: c3c100a181b731f40b7f2fddf004aa023f79d64f489706a28bc23ff88e87f6a64b3c6651fbec3a84a53960b75159574d7a7385709847a62ddb7ad6af76f49138
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.14.2":
+  version: 8.16.0
+  resolution: "ws@npm:8.16.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: feb3eecd2bae82fa8a8beef800290ce437d8b8063bdc69712725f21aef77c49cb2ff45c6e5e7fce622248f9c7abaee506bae0a9064067ffd6935460c7357321b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
1. 웹에서 새로 생성된 거래글을 discord channel에 알림보내기

## 어떻게 해결했나요?
1. offer, demand, swap created event가 publish 되면,  discord webhookClient를 통해 discord channel로 webhook 전송

## 참고 자료
https://discordjs.guide/popular-topics/webhooks.html#sending-messages