### PR TITLE
feat: exclude post version, include reportedPost in report response

### DIFF
--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -338,6 +338,22 @@ type PostPreviewResponse {
   user: UserResponse!
 }
 
+type PostPreviewWithoutUserResponse {
+  archivedAt: DateTime
+  categoryId: String!
+  createdAt: DateTime!
+  groupId: String!
+  id: ID!
+  pending: String
+  reportCommentCount: Int!
+  reportCount: Int!
+  slug: String
+  thumbnail: String
+  title: String!
+  type: String!
+  updatedAt: DateTime!
+}
+
 type PostResponse {
   archivedAt: DateTime
   category: CategoryResponse!
@@ -421,6 +437,7 @@ type ReportResponse {
   id: ID!
   reason: String!
   reportedCommentId: ID
+  reportedPost: PostPreviewWithoutUserResponse
   reportedPostId: ID
   reportedUser: AuthorResponse!
   status: String!

--- a/libs/domains/src/post/application/dtos/post-preview-without-user.response.ts
+++ b/libs/domains/src/post/application/dtos/post-preview-without-user.response.ts
@@ -1,0 +1,47 @@
+import { Field, ID, ObjectType, Int } from '@nestjs/graphql';
+
+@ObjectType()
+export class PostPreviewWithoutUserResponse {
+  @Field(() => ID)
+  id: string;
+
+  @Field()
+  createdAt: Date;
+
+  @Field()
+  updatedAt: Date;
+
+  @Field(() => Date, { nullable: true })
+  archivedAt: Date | null;
+
+  @Field(() => String, { nullable: true })
+  pending: string | null;
+
+  @Field()
+  type: string;
+
+  @Field()
+  title: string;
+
+  @Field(() => String, { nullable: true })
+  slug: string | null;
+
+  @Field(() => String, { nullable: true })
+  thumbnail: string | null;
+
+  @Field()
+  groupId: string;
+
+  @Field()
+  categoryId: string;
+
+  @Field(() => Int)
+  reportCount: number;
+
+  @Field(() => Int)
+  reportCommentCount: number;
+
+  constructor(partial: Partial<PostPreviewWithoutUserResponse>) {
+    Object.assign(this, partial);
+  }
+}

--- a/libs/domains/src/post/application/dtos/post-preview.response.ts
+++ b/libs/domains/src/post/application/dtos/post-preview.response.ts
@@ -1,51 +1,14 @@
-import { Field, ID, ObjectType, Int } from '@nestjs/graphql';
+import { Field, ObjectType } from '@nestjs/graphql';
 import { UserResponse } from '@lib/domains/user/application/dtos/user.response';
+import { PostPreviewWithoutUserResponse } from './post-preview-without-user.response';
 
 @ObjectType()
-export class PostPreviewResponse {
-  @Field(() => ID)
-  id: string;
-
-  @Field()
-  createdAt: Date;
-
-  @Field()
-  updatedAt: Date;
-
-  @Field(() => Date, { nullable: true })
-  archivedAt: Date | null;
-
-  @Field(() => String, { nullable: true })
-  pending: string | null;
-
-  @Field()
-  type: string;
-
-  @Field()
-  title: string;
-
-  @Field(() => String, { nullable: true })
-  slug: string | null;
-
-  @Field(() => String, { nullable: true })
-  thumbnail: string | null;
-
-  @Field()
-  groupId: string;
-
-  @Field()
-  categoryId: string;
-
+export class PostPreviewResponse extends PostPreviewWithoutUserResponse {
   @Field(() => UserResponse)
   user: UserResponse;
 
-  @Field(() => Int)
-  reportCount: number;
-
-  @Field(() => Int)
-  reportCommentCount: number;
-
   constructor(partial: Partial<PostPreviewResponse>) {
+    super(partial);
     Object.assign(this, partial);
   }
 }

--- a/libs/domains/src/report/application/dtos/report.response.ts
+++ b/libs/domains/src/report/application/dtos/report.response.ts
@@ -1,10 +1,14 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 import { VersionResponse } from '@lib/domains/version/application/dtos/version.response';
+import { PostPreviewWithoutUserResponse } from '@lib/domains/post/application/dtos/post-preview-without-user.response';
 import { ReportPreviewResponse } from './report-preview.response';
 import { ReportCommentResponse } from './report-comment.response';
 
 @ObjectType()
 export class ReportResponse extends ReportPreviewResponse {
+  @Field(() => PostPreviewWithoutUserResponse, { nullable: true })
+  reportedPost: PostPreviewWithoutUserResponse | null;
+
   @Field(() => [ReportCommentResponse])
   comments: ReportCommentResponse[];
 


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
post와 offer 양쪽의 version을 처리해야 하는 복잡성

## 어떻게 해결했나요?
1. post에서 자주 변경되는 content를 offer로 이동
2. post에는 title과 metadata를 저장, 도메인 데이터는 offer에서 관리
3. report - include reportedPost, offer version