### PR TITLE
feat: add where, orderBy args in findUsers query handler

### DIFF
--- a/apps/api/src/app/user/user.resolver.ts
+++ b/apps/api/src/app/user/user.resolver.ts
@@ -3,7 +3,6 @@ import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { UpdateUserInput } from '@lib/domains/user/application/commands/update-user/update-user.input';
 import { UpdateUserCommand } from '@lib/domains/user/application/commands/update-user/update-user.command';
 import { MyUserResponse } from '@lib/domains/user/application/dtos/my-user.response';
-import { PaginationArgs } from '@lib/shared/cqrs/queries/pagination/pagination.args';
 import { FindUsersQuery } from '@lib/domains/user/application/queries/find-users/find-users.query';
 import { PaginatedUsersResponse } from '@lib/domains/user/application/queries/find-users/paginated-users.response';
 import { UserResponse } from '@lib/domains/user/application/dtos/user.response';
@@ -20,6 +19,7 @@ import { ExtractedUser } from '@lib/domains/auth/decorators/extracted-user/extra
 import { ExtractedJwtPayload } from '@lib/domains/auth/decorators/extracted-jwt-payload/extracted-jwt-payload.decorator';
 import { JwtPayload } from '@lib/shared/jwt/jwt.interfaces';
 import { RequiredJwtUserGuard } from '@lib/domains/auth/guards/jwt/required-jwt-user.guard';
+import { FindUsersArgs } from '@lib/domains/user/application/queries/find-users/find-users.args';
 import { GqlThrottlerBehindProxyGuard } from '../throttler/gql-throttler-behind-proxy.guard';
 
 @UseGuards(GqlThrottlerBehindProxyGuard)
@@ -49,8 +49,8 @@ export class UserResolver {
   }
 
   @Query(() => PaginatedUsersResponse)
-  async findUsers(@Args() paginationArgs: PaginationArgs) {
-    const query = new FindUsersQuery(paginationArgs);
+  async findUsers(@Args() args: FindUsersArgs) {
+    const query = new FindUsersQuery({ args });
     return this.queryBus.execute(query);
   }
 

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -396,7 +396,7 @@ type Query {
   findUser(provider: String, socialId: String, username: String): UserResponse
   findUserImageById(id: ID!): UserImageResponse
   findUserImagesOfRef(refId: ID!, type: String!): [UserImageResponse!]!
-  findUsers(cursor: ID, skip: Int! = 1, take: Int!): PaginatedUsersResponse!
+  findUsers(cursor: ID, keyword: String, orderBy: JSON, skip: Int! = 1, take: Int!, where: JSON): PaginatedUsersResponse!
   findVersion(id: ID!): VersionResponse
   findVersionPreview(id: ID, refId: ID): VersionPreviewResponse
 }

--- a/libs/domains/src/user/application/queries/find-my-user/find-my-user.args.ts
+++ b/libs/domains/src/user/application/queries/find-my-user/find-my-user.args.ts
@@ -5,16 +5,16 @@ import { IsOptional, IsString, IsUUID } from 'class-validator';
 export class FindMyUserArgs {
   @IsOptional()
   @IsUUID()
-  @Field(() => ID)
+  @Field(() => ID, { nullable: true })
   userId?: string;
 
   @IsOptional()
   @IsString()
-  @Field(() => String)
+  @Field(() => String, { nullable: true })
   provider?: string;
 
   @IsOptional()
   @IsString()
-  @Field(() => String)
+  @Field(() => String, { nullable: true })
   socialId?: string;
 }

--- a/libs/domains/src/user/application/queries/find-users/find-users-order-by.args.ts
+++ b/libs/domains/src/user/application/queries/find-users/find-users-order-by.args.ts
@@ -1,0 +1,9 @@
+import { ArgsType, Field } from '@nestjs/graphql';
+import { IsOptional } from 'class-validator';
+
+@ArgsType()
+export class FindUsersOrderByArgs {
+  @IsOptional()
+  @Field(() => String, { nullable: true })
+  createdAt?: 'asc' | 'desc';
+}

--- a/libs/domains/src/user/application/queries/find-users/find-users-where.args.ts
+++ b/libs/domains/src/user/application/queries/find-users/find-users-where.args.ts
@@ -1,0 +1,9 @@
+import { ArgsType, Field, ID } from '@nestjs/graphql';
+import { IsOptional } from 'class-validator';
+
+@ArgsType()
+export class FindUsersWhereArgs {
+  @IsOptional()
+  @Field(() => ID, { nullable: true })
+  userId?: string;
+}

--- a/libs/domains/src/user/application/queries/find-users/find-users.args.ts
+++ b/libs/domains/src/user/application/queries/find-users/find-users.args.ts
@@ -1,0 +1,17 @@
+import { PaginationSearchArgs } from '@lib/shared/cqrs/queries/pagination/pagination-search.args';
+import { ArgsType, Field } from '@nestjs/graphql';
+import { GraphQLJSON } from 'graphql-type-json';
+import { IsOptional } from 'class-validator';
+import { FindUsersWhereArgs } from './find-users-where.args';
+import { FindUsersOrderByArgs } from './find-users-order-by.args';
+
+@ArgsType()
+export class FindUsersArgs extends PaginationSearchArgs {
+  @IsOptional()
+  @Field(() => GraphQLJSON, { nullable: true })
+  where?: FindUsersWhereArgs;
+
+  @IsOptional()
+  @Field(() => GraphQLJSON, { nullable: true })
+  orderBy?: FindUsersOrderByArgs;
+}

--- a/libs/domains/src/user/application/queries/find-users/find-users.handler.ts
+++ b/libs/domains/src/user/application/queries/find-users/find-users.handler.ts
@@ -18,12 +18,21 @@ export class FindUsersHandler extends PrismaQueryHandler<FindUsersQuery, UserRes
         }
       : undefined;
     const users = await this.prismaService.user.findMany({
+      where: {
+        id: query.where?.userId,
+        username: {
+          contains: query.keyword,
+          mode: 'insensitive',
+        },
+      },
       cursor,
       take: query.take + 1,
       skip: query.skip,
-      orderBy: {
-        createdAt: 'desc',
-      },
+      orderBy: [
+        {
+          createdAt: query.orderBy?.createdAt,
+        },
+      ],
     });
     return paginate<UserResponse>(this.parseResponses(users), 'id', query.take);
   }

--- a/libs/domains/src/user/application/queries/find-users/find-users.query.ts
+++ b/libs/domains/src/user/application/queries/find-users/find-users.query.ts
@@ -1,3 +1,19 @@
 import { PaginationQuery } from '@lib/shared/cqrs/queries/pagination/pagination.query';
+import { FindUsersWhereArgs } from './find-users-where.args';
+import { FindUsersOrderByArgs } from './find-users-order-by.args';
+import { FindUsersArgs } from './find-users.args';
 
-export class FindUsersQuery extends PaginationQuery {}
+export class FindUsersQuery extends PaginationQuery {
+  where?: FindUsersWhereArgs;
+
+  orderBy?: FindUsersOrderByArgs;
+
+  keyword?: string;
+
+  constructor({ args }: { args: FindUsersArgs }) {
+    super(args);
+    this.where = args.where;
+    this.orderBy = args.orderBy;
+    this.keyword = args.keyword;
+  }
+}


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
UserFeed의 users pagination 구현

## 어떻게 해결했나요?
1. FindUsersWhereArgs, FindUsersOrderByArgs
2. contains: query.keyword

## 참고 자료
https://www.prisma.io/docs/orm/prisma-client/queries/filtering-and-sorting