### PR TITLE
feat: add create reaction, cancel reaction handler

### DIFF
--- a/apps/api/src/api.module.ts
+++ b/apps/api/src/api.module.ts
@@ -24,6 +24,7 @@ import { UserReviewModule } from './app/user-review/user-review.module';
 import { TagModule } from './app/tag/tag.module';
 import { PostModule } from './app/post/post.module';
 import { EmojiModule } from './app/emoji/emoji.module';
+import { ReactionModule } from './app/reaction/reaction.module';
 
 @Module({
   imports: [
@@ -64,6 +65,7 @@ import { EmojiModule } from './app/emoji/emoji.module';
     UserReviewModule,
     TagModule,
     EmojiModule,
+    ReactionModule,
   ],
 })
 export class ApiModule {}

--- a/apps/api/src/app/reaction/reaction.module.ts
+++ b/apps/api/src/app/reaction/reaction.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { CqrsModule } from '@nestjs/cqrs';
+import { PrismaModule } from '@lib/shared/prisma/prisma.module';
+import { REACTION_PROVIDERS } from '@lib/domains/reaction/reaction.providers';
+import { ReactionResolver } from './reaction.resolver';
+
+@Module({
+  imports: [CqrsModule, PrismaModule],
+  providers: [ReactionResolver, ...REACTION_PROVIDERS],
+})
+export class ReactionModule {}

--- a/apps/api/src/app/reaction/reaction.resolver.ts
+++ b/apps/api/src/app/reaction/reaction.resolver.ts
@@ -43,6 +43,6 @@ export class ReactionResolver {
     @ExtractedUser() user: MyUserResponse,
   ): Promise<string> {
     await this.commandBus.execute(new CancelReactionCommand({ input, user }));
-    return input.reactionId;
+    return input.emojiId;
   }
 }

--- a/apps/api/src/app/reaction/reaction.resolver.ts
+++ b/apps/api/src/app/reaction/reaction.resolver.ts
@@ -1,0 +1,48 @@
+import { Args, Mutation, Resolver } from '@nestjs/graphql';
+import { CommandBus, QueryBus } from '@nestjs/cqrs';
+import { UseGuards } from '@nestjs/common';
+import { BlocklistRoleNames } from '@lib/domains/auth/decorators/blocklist-role-names/blocklist-role-names.decorator';
+import { AllowlistRoleNames } from '@lib/domains/auth/decorators/allowlist-role-names/allowlist-role-names.decorator';
+import { RootRoleGuard } from '@lib/domains/auth/guards/role/root-role.guard';
+import { RequiredJwtUserGuard } from '@lib/domains/auth/guards/jwt/required-jwt-user.guard';
+import { CreateReactionInput } from '@lib/domains/reaction/application/commands/create-reaction/create-reaction.input';
+import { ROOT_BLOCKLIST_ROLE_NAMES } from '@lib/domains/role/domain/role.types';
+import { CancelReactionInput } from '@lib/domains/reaction/application/commands/cancel-reaction/cancel-reaction.input';
+import { CreateReactionCommand } from '@lib/domains/reaction/application/commands/create-reaction/create-reaction.command';
+import { ExtractedUser } from '@lib/domains/auth/decorators/extracted-user/extracted-user.decorator';
+import { MyUserResponse } from '@lib/domains/user/application/dtos/my-user.response';
+import { CancelReactionCommand } from '@lib/domains/reaction/application/commands/cancel-reaction/cancel-reaction.command';
+import { GqlThrottlerBehindProxyGuard } from '../throttler/gql-throttler-behind-proxy.guard';
+
+@UseGuards(GqlThrottlerBehindProxyGuard)
+@Resolver()
+export class ReactionResolver {
+  constructor(
+    private readonly commandBus: CommandBus,
+    private readonly queryBus: QueryBus,
+  ) {}
+
+  @BlocklistRoleNames([...ROOT_BLOCKLIST_ROLE_NAMES])
+  @AllowlistRoleNames([])
+  @UseGuards(RequiredJwtUserGuard, RootRoleGuard)
+  @Mutation(() => String)
+  async createReaction(
+    @Args('input') input: CreateReactionInput,
+    @ExtractedUser() user: MyUserResponse,
+  ): Promise<string> {
+    await this.commandBus.execute(new CreateReactionCommand({ input, user }));
+    return input.id;
+  }
+
+  @BlocklistRoleNames([...ROOT_BLOCKLIST_ROLE_NAMES])
+  @AllowlistRoleNames([])
+  @UseGuards(RequiredJwtUserGuard, RootRoleGuard)
+  @Mutation(() => String)
+  async cancelReaction(
+    @Args('input') input: CancelReactionInput,
+    @ExtractedUser() user: MyUserResponse,
+  ): Promise<string> {
+    await this.commandBus.execute(new CancelReactionCommand({ input, user }));
+    return input.reactionId;
+  }
+}

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -445,6 +445,28 @@ type PostResponse {
   user: AuthorResponse!
 }
 
+type PostWithReactionsResponse {
+  archivedAt: DateTime
+  category: CategoryResponse
+  categoryId: String
+  createdAt: DateTime!
+  group: GroupProfileResponse!
+  groupId: String!
+  id: ID!
+  images: [UserImageResponse!]!
+  pending: String
+  reactions: [ReactionSummaryResponse!]!
+  reportCommentCount: Int!
+  reportCount: Int!
+  slug: String
+  tags: [TagResponse!]!
+  thumbnail: String
+  title: String!
+  type: String!
+  updatedAt: DateTime!
+  user: AuthorResponse!
+}
+
 type Query {
   findAuthor(id: ID, username: String): AuthorResponse
   findComment(id: ID, postId: ID): CommentResponse
@@ -474,6 +496,12 @@ type Query {
   findUsers(cursor: ID, keyword: String, orderBy: JSON, skip: Int! = 1, take: Int!, where: JSON): PaginatedUsersResponse!
   findVersion(id: ID!): VersionResponse
   findVersionPreview(id: ID, refId: ID): VersionPreviewResponse
+}
+
+type ReactionSummaryResponse {
+  count: Int!
+  emoji: EmojiResponse!
+  me: Boolean!
 }
 
 type ReportCommentResponse {
@@ -698,7 +726,7 @@ type UserReviewResponse {
   createdAt: DateTime!
   id: ID!
   offerId: String
-  post: PostResponse!
+  post: PostWithReactionsResponse!
   rating: Int!
   reviewedUser: AuthorResponse!
   status: String!

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -19,6 +19,10 @@ input BumpOfferInput {
   offerId: ID!
 }
 
+input CancelReactionInput {
+  reactionId: ID!
+}
+
 type CategoryResponse {
   description: String
   id: ID!
@@ -99,6 +103,13 @@ input CreatePostInput {
   tagIds: [ID!]
   title: String!
   type: String!
+}
+
+input CreateReactionInput {
+  commentId: ID
+  emojiId: ID!
+  id: ID!
+  postId: ID
 }
 
 input CreateReportInput {
@@ -235,11 +246,13 @@ input LinkSocialProfileInput {
 
 type Mutation {
   bumpOffer(input: BumpOfferInput!): OfferPreviewResponse!
+  cancelReaction(input: CancelReactionInput!): String!
   commentReport(input: CommentReportInput!): ReportCommentResponse!
   createComment(input: CreateCommentInput!): String!
   createGroup(input: CreateGroupInput!): String!
   createManyUserImage(input: CreateManyUserImageInput!): String!
   createOffer(input: CreateOfferInput!): String!
+  createReaction(input: CreateReactionInput!): String!
   createReport(input: CreateReportInput!): String!
   createRole(input: CreateRoleInput!): String!
   createSignedUrl(input: CreateSignedUrlInput!): SignedUrlResponse!

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -20,7 +20,9 @@ input BumpOfferInput {
 }
 
 input CancelReactionInput {
-  reactionId: ID!
+  commentId: ID
+  emojiId: ID!
+  postId: ID
 }
 
 type CategoryResponse {
@@ -499,9 +501,11 @@ type Query {
 }
 
 type ReactionSummaryResponse {
+  commentId: ID
   count: Int!
   emoji: EmojiResponse!
   me: Boolean!
+  postId: ID
 }
 
 type ReportCommentResponse {

--- a/libs/domains/src/emoji/application/dtos/emoji.response.ts
+++ b/libs/domains/src/emoji/application/dtos/emoji.response.ts
@@ -9,13 +9,13 @@ export class EmojiResponse {
   name: string;
 
   @Field(() => String, { nullable: true })
-  url?: string;
+  url: string | null;
 
   @Field(() => Int)
   position: number;
 
   @Field(() => ID, { nullable: true })
-  groupId?: string;
+  groupId: string | null;
 
   constructor(partial: Partial<EmojiResponse>) {
     Object.assign(this, partial);

--- a/libs/domains/src/post/application/dtos/post-with-reactions.response.ts
+++ b/libs/domains/src/post/application/dtos/post-with-reactions.response.ts
@@ -1,0 +1,14 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+import { ReactionSummaryResponse } from '@lib/domains/reaction/application/dtos/reaction-summary.response';
+import { PostResponse } from './post.response';
+
+@ObjectType()
+export class PostWithReactionsResponse extends PostResponse {
+  @Field(() => [ReactionSummaryResponse])
+  reactions: ReactionSummaryResponse[];
+
+  constructor(partial: Partial<PostWithReactionsResponse>) {
+    super(partial);
+    Object.assign(this, partial);
+  }
+}

--- a/libs/domains/src/reaction/adapter/out/persistence/reaction.repository.ts
+++ b/libs/domains/src/reaction/adapter/out/persistence/reaction.repository.ts
@@ -1,0 +1,52 @@
+import _ from 'lodash';
+import { Injectable } from '@nestjs/common';
+import { PrismaRepository } from '@lib/shared/cqrs/repositories/prisma-repository';
+import { ReactionEntity } from '@lib/domains/reaction/domain/reaction.entity';
+import { ReactionSavePort } from '@lib/domains/reaction/application/ports/out/reaction.save.port';
+import { ReactionLoadPort } from '@lib/domains/reaction/application/ports/out/reaction.load.port';
+
+@Injectable()
+export class ReactionRepository
+  extends PrismaRepository<ReactionEntity>
+  implements ReactionSavePort, ReactionLoadPort
+{
+  constructor() {
+    super(ReactionEntity);
+  }
+
+  async findById(id: string): Promise<ReactionEntity | null> {
+    const reaction = await this.prismaService.reaction.findUnique({
+      where: {
+        id,
+      },
+    });
+    return this.toEntity(reaction);
+  }
+
+  async create(reaction: ReactionEntity): Promise<void> {
+    await this.prismaService.reaction.create({
+      data: _.pick(reaction, ['id', 'emojiId', 'userId', 'postId', 'commentId']),
+    });
+  }
+
+  async createMany(reactions: ReactionEntity[]): Promise<void> {
+    await reactions.map(async (reaction) => this.create(reaction));
+  }
+
+  async save(reaction: ReactionEntity): Promise<void> {
+    await this.prismaService.reaction.update({
+      where: {
+        id: reaction.id,
+      },
+      data: _.pick(reaction, 'canceledAt'),
+    });
+  }
+
+  async delete(reaction: ReactionEntity): Promise<void> {
+    await this.prismaService.reaction.delete({
+      where: {
+        id: reaction.id,
+      },
+    });
+  }
+}

--- a/libs/domains/src/reaction/adapter/out/persistence/reaction.repository.ts
+++ b/libs/domains/src/reaction/adapter/out/persistence/reaction.repository.ts
@@ -23,6 +23,28 @@ export class ReactionRepository
     return this.toEntity(reaction);
   }
 
+  async findReaction({
+    emojiId,
+    postId,
+    commentId,
+    userId,
+  }: {
+    emojiId: string;
+    postId?: string | undefined;
+    commentId?: string | undefined;
+    userId: string;
+  }) {
+    const reaction = await this.prismaService.reaction.findFirst({
+      where: {
+        emojiId,
+        postId,
+        commentId,
+        userId,
+      },
+    });
+    return this.toEntity(reaction);
+  }
+
   async create(reaction: ReactionEntity): Promise<void> {
     await this.prismaService.reaction.create({
       data: _.pick(reaction, ['id', 'emojiId', 'userId', 'postId', 'commentId']),

--- a/libs/domains/src/reaction/application/commands/cancel-reaction/cancel-reaction.command.ts
+++ b/libs/domains/src/reaction/application/commands/cancel-reaction/cancel-reaction.command.ts
@@ -1,0 +1,14 @@
+import { ICommand } from '@nestjs/cqrs/dist';
+import { MyUserResponse } from '@lib/domains/user/application/dtos/my-user.response';
+import { CancelReactionInput } from './cancel-reaction.input';
+
+export class CancelReactionCommand implements ICommand {
+  reactionId: string;
+
+  user: MyUserResponse;
+
+  constructor({ input, user }: { input: CancelReactionInput; user: MyUserResponse }) {
+    this.reactionId = input.reactionId;
+    this.user = user;
+  }
+}

--- a/libs/domains/src/reaction/application/commands/cancel-reaction/cancel-reaction.command.ts
+++ b/libs/domains/src/reaction/application/commands/cancel-reaction/cancel-reaction.command.ts
@@ -3,12 +3,18 @@ import { MyUserResponse } from '@lib/domains/user/application/dtos/my-user.respo
 import { CancelReactionInput } from './cancel-reaction.input';
 
 export class CancelReactionCommand implements ICommand {
-  reactionId: string;
+  emojiId: string;
+
+  postId?: string;
+
+  commentId?: string;
 
   user: MyUserResponse;
 
   constructor({ input, user }: { input: CancelReactionInput; user: MyUserResponse }) {
-    this.reactionId = input.reactionId;
+    this.emojiId = input.emojiId;
+    this.postId = input.postId;
+    this.commentId = input.commentId;
     this.user = user;
   }
 }

--- a/libs/domains/src/reaction/application/commands/cancel-reaction/cancel-reaction.handler.ts
+++ b/libs/domains/src/reaction/application/commands/cancel-reaction/cancel-reaction.handler.ts
@@ -1,0 +1,28 @@
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs/dist';
+import { ForbiddenException, Inject, NotFoundException } from '@nestjs/common';
+import { ReactionErrorMessage } from '@lib/domains/reaction/domain/reaction.error.message';
+import { CancelReactionCommand } from './cancel-reaction.command';
+import { ReactionLoadPort } from '../../ports/out/reaction.load.port';
+import { ReactionSavePort } from '../../ports/out/reaction.save.port';
+
+@CommandHandler(CancelReactionCommand)
+export class CancelReactionHandler implements ICommandHandler<CancelReactionCommand> {
+  constructor(
+    @Inject('ReactionSavePort') private savePort: ReactionSavePort,
+    @Inject('ReactionLoadPort') private loadPort: ReactionLoadPort,
+  ) {}
+
+  async execute(command: CancelReactionCommand): Promise<void> {
+    const reaction = await this.loadPort.findById(command.reactionId);
+    if (!reaction) throw new NotFoundException(ReactionErrorMessage.REACTION_NOT_FOUND);
+
+    if (!reaction.isAuthorized(command.user.id)) {
+      throw new ForbiddenException(
+        ReactionErrorMessage.REACTION_CANCEL_REQUEST_FROM_UNAUTHORIZED_USER,
+      );
+    }
+
+    reaction.cancel();
+    await this.savePort.save(reaction);
+  }
+}

--- a/libs/domains/src/reaction/application/commands/cancel-reaction/cancel-reaction.handler.ts
+++ b/libs/domains/src/reaction/application/commands/cancel-reaction/cancel-reaction.handler.ts
@@ -13,7 +13,15 @@ export class CancelReactionHandler implements ICommandHandler<CancelReactionComm
   ) {}
 
   async execute(command: CancelReactionCommand): Promise<void> {
-    const reaction = await this.loadPort.findById(command.reactionId);
+    if (!command.postId && !command.commentId)
+      throw new ForbiddenException(ReactionErrorMessage.INVALID_REACTION_REQUEST);
+
+    const reaction = await this.loadPort.findReaction({
+      emojiId: command.emojiId,
+      postId: command.postId,
+      commentId: command.commentId,
+      userId: command.user.id,
+    });
     if (!reaction) throw new NotFoundException(ReactionErrorMessage.REACTION_NOT_FOUND);
 
     if (!reaction.isAuthorized(command.user.id)) {

--- a/libs/domains/src/reaction/application/commands/cancel-reaction/cancel-reaction.input.ts
+++ b/libs/domains/src/reaction/application/commands/cancel-reaction/cancel-reaction.input.ts
@@ -1,0 +1,9 @@
+import { Field, ID, InputType } from '@nestjs/graphql';
+import { IsUUID } from 'class-validator';
+
+@InputType()
+export class CancelReactionInput {
+  @IsUUID()
+  @Field(() => ID)
+  reactionId: string;
+}

--- a/libs/domains/src/reaction/application/commands/cancel-reaction/cancel-reaction.input.ts
+++ b/libs/domains/src/reaction/application/commands/cancel-reaction/cancel-reaction.input.ts
@@ -1,9 +1,19 @@
 import { Field, ID, InputType } from '@nestjs/graphql';
-import { IsUUID } from 'class-validator';
+import { IsOptional, IsUUID } from 'class-validator';
 
 @InputType()
 export class CancelReactionInput {
   @IsUUID()
   @Field(() => ID)
-  reactionId: string;
+  emojiId: string;
+
+  @IsOptional()
+  @IsUUID()
+  @Field(() => ID, { nullable: true })
+  postId?: string;
+
+  @IsOptional()
+  @IsUUID()
+  @Field(() => ID, { nullable: true })
+  commentId?: string;
 }

--- a/libs/domains/src/reaction/application/commands/create-reaction/create-reaction.command.ts
+++ b/libs/domains/src/reaction/application/commands/create-reaction/create-reaction.command.ts
@@ -1,0 +1,23 @@
+import { ICommand } from '@nestjs/cqrs/dist';
+import { MyUserResponse } from '@lib/domains/user/application/dtos/my-user.response';
+import { CreateReactionInput } from './create-reaction.input';
+
+export class CreateReactionCommand implements ICommand {
+  id: string;
+
+  emojiId: string;
+
+  postId?: string;
+
+  commentId?: string;
+
+  user: MyUserResponse;
+
+  constructor({ input, user }: { input: CreateReactionInput; user: MyUserResponse }) {
+    this.id = input.id;
+    this.emojiId = input.emojiId;
+    this.postId = input.postId;
+    this.commentId = input.commentId;
+    this.user = user;
+  }
+}

--- a/libs/domains/src/reaction/application/commands/create-reaction/create-reaction.handler.ts
+++ b/libs/domains/src/reaction/application/commands/create-reaction/create-reaction.handler.ts
@@ -9,7 +9,10 @@ export class CreateReactionHandler implements ICommandHandler<CreateReactionComm
   constructor(@Inject('ReactionSavePort') private savePort: ReactionSavePort) {}
 
   async execute(command: CreateReactionCommand): Promise<void> {
-    const reawction = new ReactionEntity(command);
-    await this.savePort.create(reawction);
+    const reaction = new ReactionEntity({
+      ...command,
+      userId: command.user.id,
+    });
+    await this.savePort.create(reaction);
   }
 }

--- a/libs/domains/src/reaction/application/commands/create-reaction/create-reaction.handler.ts
+++ b/libs/domains/src/reaction/application/commands/create-reaction/create-reaction.handler.ts
@@ -1,0 +1,15 @@
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs/dist';
+import { Inject } from '@nestjs/common';
+import { ReactionEntity } from '@lib/domains/reaction/domain/reaction.entity';
+import { CreateReactionCommand } from './create-reaction.command';
+import { ReactionSavePort } from '../../ports/out/reaction.save.port';
+
+@CommandHandler(CreateReactionCommand)
+export class CreateReactionHandler implements ICommandHandler<CreateReactionCommand> {
+  constructor(@Inject('ReactionSavePort') private savePort: ReactionSavePort) {}
+
+  async execute(command: CreateReactionCommand): Promise<void> {
+    const reawction = new ReactionEntity(command);
+    await this.savePort.create(reawction);
+  }
+}

--- a/libs/domains/src/reaction/application/commands/create-reaction/create-reaction.handler.ts
+++ b/libs/domains/src/reaction/application/commands/create-reaction/create-reaction.handler.ts
@@ -3,16 +3,30 @@ import { Inject } from '@nestjs/common';
 import { ReactionEntity } from '@lib/domains/reaction/domain/reaction.entity';
 import { CreateReactionCommand } from './create-reaction.command';
 import { ReactionSavePort } from '../../ports/out/reaction.save.port';
+import { ReactionLoadPort } from '../../ports/out/reaction.load.port';
 
 @CommandHandler(CreateReactionCommand)
 export class CreateReactionHandler implements ICommandHandler<CreateReactionCommand> {
-  constructor(@Inject('ReactionSavePort') private savePort: ReactionSavePort) {}
+  constructor(
+    @Inject('ReactionLoadPort') private loadPort: ReactionLoadPort,
+    @Inject('ReactionSavePort') private savePort: ReactionSavePort,
+  ) {}
 
   async execute(command: CreateReactionCommand): Promise<void> {
-    const reaction = new ReactionEntity({
+    const existingReaction = await this.loadPort.findReaction({
       ...command,
       userId: command.user.id,
     });
-    await this.savePort.create(reaction);
+
+    if (existingReaction) {
+      existingReaction.readd();
+      await this.savePort.save(existingReaction);
+    } else {
+      const reaction = new ReactionEntity({
+        ...command,
+        userId: command.user.id,
+      });
+      await this.savePort.create(reaction);
+    }
   }
 }

--- a/libs/domains/src/reaction/application/commands/create-reaction/create-reaction.input.ts
+++ b/libs/domains/src/reaction/application/commands/create-reaction/create-reaction.input.ts
@@ -1,0 +1,23 @@
+import { Field, ID, InputType } from '@nestjs/graphql';
+import { IsOptional, IsUUID } from 'class-validator';
+
+@InputType()
+export class CreateReactionInput {
+  @IsUUID()
+  @Field(() => ID)
+  id: string;
+
+  @IsUUID()
+  @Field(() => ID)
+  emojiId: string;
+
+  @IsOptional()
+  @IsUUID()
+  @Field(() => ID, { nullable: true })
+  postId?: string;
+
+  @IsOptional()
+  @IsUUID()
+  @Field(() => ID, { nullable: true })
+  commentId?: string;
+}

--- a/libs/domains/src/reaction/application/commands/reaction.command.providers.ts
+++ b/libs/domains/src/reaction/application/commands/reaction.command.providers.ts
@@ -1,0 +1,4 @@
+import { CancelReactionHandler } from './cancel-reaction/cancel-reaction.handler';
+import { CreateReactionHandler } from './create-reaction/create-reaction.handler';
+
+export const REACTION_COMMAND_PROVIDERS = [CreateReactionHandler, CancelReactionHandler];

--- a/libs/domains/src/reaction/application/dtos/reaction-summary.response.ts
+++ b/libs/domains/src/reaction/application/dtos/reaction-summary.response.ts
@@ -1,5 +1,5 @@
 import { EmojiResponse } from '@lib/domains/emoji/application/dtos/emoji.response';
-import { Field, Int, ObjectType } from '@nestjs/graphql';
+import { Field, ID, Int, ObjectType } from '@nestjs/graphql';
 
 @ObjectType()
 export class ReactionSummaryResponse {
@@ -11,6 +11,12 @@ export class ReactionSummaryResponse {
 
   @Field(() => Boolean)
   me: boolean;
+
+  @Field(() => ID, { nullable: true })
+  postId: string | null;
+
+  @Field(() => ID, { nullable: true })
+  commentId: string | null;
 
   constructor(partial: Partial<ReactionSummaryResponse>) {
     Object.assign(this, partial);

--- a/libs/domains/src/reaction/application/dtos/reaction-summary.response.ts
+++ b/libs/domains/src/reaction/application/dtos/reaction-summary.response.ts
@@ -1,0 +1,18 @@
+import { EmojiResponse } from '@lib/domains/emoji/application/dtos/emoji.response';
+import { Field, Int, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class ReactionSummaryResponse {
+  @Field(() => EmojiResponse)
+  emoji: EmojiResponse;
+
+  @Field(() => Int)
+  count: number;
+
+  @Field(() => Boolean)
+  me: boolean;
+
+  constructor(partial: Partial<ReactionSummaryResponse>) {
+    Object.assign(this, partial);
+  }
+}

--- a/libs/domains/src/reaction/application/ports/out/reaction.load.port.ts
+++ b/libs/domains/src/reaction/application/ports/out/reaction.load.port.ts
@@ -1,0 +1,4 @@
+import { ReactionEntity } from '@lib/domains/reaction/domain/reaction.entity';
+import { LoadPort } from '@lib/shared/cqrs/ports/load.port';
+
+export interface ReactionLoadPort extends LoadPort<ReactionEntity> {}

--- a/libs/domains/src/reaction/application/ports/out/reaction.load.port.ts
+++ b/libs/domains/src/reaction/application/ports/out/reaction.load.port.ts
@@ -1,4 +1,16 @@
 import { ReactionEntity } from '@lib/domains/reaction/domain/reaction.entity';
 import { LoadPort } from '@lib/shared/cqrs/ports/load.port';
 
-export interface ReactionLoadPort extends LoadPort<ReactionEntity> {}
+export interface ReactionLoadPort extends LoadPort<ReactionEntity> {
+  findReaction: ({
+    emojiId,
+    postId,
+    commentId,
+    userId,
+  }: {
+    emojiId: string;
+    postId?: string;
+    commentId?: string;
+    userId: string;
+  }) => Promise<ReactionEntity | null>;
+}

--- a/libs/domains/src/reaction/application/ports/out/reaction.save.port.ts
+++ b/libs/domains/src/reaction/application/ports/out/reaction.save.port.ts
@@ -1,0 +1,4 @@
+import { ReactionEntity } from '@lib/domains/reaction/domain/reaction.entity';
+import { SavePort } from '@lib/shared/cqrs/ports/save.port';
+
+export interface ReactionSavePort extends SavePort<ReactionEntity> {}

--- a/libs/domains/src/reaction/domain/reaction.entity.ts
+++ b/libs/domains/src/reaction/domain/reaction.entity.ts
@@ -29,6 +29,6 @@ export class ReactionEntity extends AggregateRoot {
   }
 
   cancel() {
-    this.canceledAt = null;
+    this.canceledAt = new Date();
   }
 }

--- a/libs/domains/src/reaction/domain/reaction.entity.ts
+++ b/libs/domains/src/reaction/domain/reaction.entity.ts
@@ -1,0 +1,34 @@
+import { AggregateRoot } from '@nestjs/cqrs';
+
+export class ReactionEntity extends AggregateRoot {
+  id: string;
+
+  createdAt: Date;
+
+  updateedAt: Date;
+
+  deletedAt: Date | null;
+
+  canceledAt: Date | null;
+
+  emojiId: string;
+
+  userId: string;
+
+  postId: string | null;
+
+  commentId: string | null;
+
+  constructor(partial: Partial<ReactionEntity>) {
+    super();
+    Object.assign(this, partial);
+  }
+
+  isAuthorized(userId: string) {
+    return this.userId === userId;
+  }
+
+  cancel() {
+    this.canceledAt = null;
+  }
+}

--- a/libs/domains/src/reaction/domain/reaction.entity.ts
+++ b/libs/domains/src/reaction/domain/reaction.entity.ts
@@ -31,4 +31,8 @@ export class ReactionEntity extends AggregateRoot {
   cancel() {
     this.canceledAt = new Date();
   }
+
+  readd() {
+    this.canceledAt = null;
+  }
 }

--- a/libs/domains/src/reaction/domain/reaction.error.message.ts
+++ b/libs/domains/src/reaction/domain/reaction.error.message.ts
@@ -1,4 +1,5 @@
 export enum ReactionErrorMessage {
   REACTION_NOT_FOUND = 'Reaction not found',
   REACTION_CANCEL_REQUEST_FROM_UNAUTHORIZED_USER = 'Reaction cancel request from unauthorized user',
+  INVALID_REACTION_REQUEST = 'Invalid reaction request',
 }

--- a/libs/domains/src/reaction/domain/reaction.error.message.ts
+++ b/libs/domains/src/reaction/domain/reaction.error.message.ts
@@ -1,0 +1,4 @@
+export enum ReactionErrorMessage {
+  REACTION_NOT_FOUND = 'Reaction not found',
+  REACTION_CANCEL_REQUEST_FROM_UNAUTHORIZED_USER = 'Reaction cancel request from unauthorized user',
+}

--- a/libs/domains/src/reaction/reaction.providers.ts
+++ b/libs/domains/src/reaction/reaction.providers.ts
@@ -1,0 +1,14 @@
+import { ReactionRepository } from './adapter/out/persistence/reaction.repository';
+import { REACTION_COMMAND_PROVIDERS } from './application/commands/reaction.command.providers';
+
+export const REACTION_PROVIDERS = [
+  {
+    provide: 'ReactionLoadPort',
+    useClass: ReactionRepository,
+  },
+  {
+    provide: 'ReactionSavePort',
+    useClass: ReactionRepository,
+  },
+  ...REACTION_COMMAND_PROVIDERS,
+];

--- a/libs/domains/src/user-review/application/dtos/user-review.response.ts
+++ b/libs/domains/src/user-review/application/dtos/user-review.response.ts
@@ -1,11 +1,11 @@
-import { PostResponse } from '@lib/domains/post/application/dtos/post.response';
 import { Field, ObjectType } from '@nestjs/graphql';
+import { PostWithReactionsResponse } from '@lib/domains/post/application/dtos/post-with-reactions.response';
 import { UserReviewPreviewResponse } from './user-review-preview.response';
 
 @ObjectType()
 export class UserReviewResponse extends UserReviewPreviewResponse {
-  @Field(() => PostResponse)
-  declare post: PostResponse;
+  @Field(() => PostWithReactionsResponse)
+  declare post: PostWithReactionsResponse;
 
   constructor(partial: Partial<UserReviewPreviewResponse>) {
     super(partial);

--- a/libs/domains/src/user-review/application/queries/find-user-review/find-user-review.handler.ts
+++ b/libs/domains/src/user-review/application/queries/find-user-review/find-user-review.handler.ts
@@ -3,6 +3,7 @@ import { PrismaQueryHandler } from '@lib/shared/cqrs/queries/handlers/prisma-que
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { USER_REVIEW } from '@lib/domains/user-review/domain/user-review.constants';
 import { UserReviewErrorMessage } from '@lib/domains/user-review/domain/user-review.error.message';
+import { ReactionSummaryResponse } from '@lib/domains/reaction/application/dtos/reaction-summary.response';
 import { FindUserReviewQuery } from './find-user-review.query';
 import { UserReviewResponse } from '../../dtos/user-review.response';
 
@@ -44,6 +45,11 @@ export class FindUserReviewHandler extends PrismaQueryHandler<
               },
             },
             tags: true,
+            reactions: {
+              include: {
+                emoji: true,
+              },
+            },
           },
         },
         reviewedUser: {
@@ -68,6 +74,25 @@ export class FindUserReviewHandler extends PrismaQueryHandler<
         UserReviewErrorMessage.FIND_USER_REVIEWS_REQUEST_FROM_UNAUTHORIZED_USER,
       );
 
+    const reactionCountsByEmoji = userReview.post.reactions.reduce(
+      (acc, reaction) => {
+        const { emoji } = reaction;
+        if (!acc[emoji.id]) {
+          acc[emoji.id] = {
+            emoji,
+            count: 0,
+            me: false,
+          };
+        }
+        acc[emoji.id].count++;
+        if (reaction.userId === query.userId) {
+          acc[emoji.id].me = true;
+        }
+        return acc;
+      },
+      {} as Record<string, ReactionSummaryResponse>,
+    );
+
     const images = await this.prismaService.userImage.findMany({
       where: {
         type: USER_REVIEW,
@@ -81,6 +106,9 @@ export class FindUserReviewHandler extends PrismaQueryHandler<
       ...userReview,
       post: {
         ...userReview.post,
+        post: {
+          reactions: reactionCountsByEmoji,
+        },
         images,
       },
     });

--- a/libs/domains/src/user-review/application/queries/find-user-review/find-user-review.handler.ts
+++ b/libs/domains/src/user-review/application/queries/find-user-review/find-user-review.handler.ts
@@ -49,6 +49,11 @@ export class FindUserReviewHandler extends PrismaQueryHandler<
               include: {
                 emoji: true,
               },
+              where: {
+                canceledAt: {
+                  equals: null,
+                },
+              },
             },
           },
         },
@@ -82,6 +87,8 @@ export class FindUserReviewHandler extends PrismaQueryHandler<
             emoji,
             count: 0,
             me: false,
+            postId: reaction.postId,
+            commentId: reaction.commentId,
           };
         }
         acc[emoji.id].count++;
@@ -106,9 +113,7 @@ export class FindUserReviewHandler extends PrismaQueryHandler<
       ...userReview,
       post: {
         ...userReview.post,
-        post: {
-          reactions: reactionCountsByEmoji,
-        },
+        reactions: Object.keys(reactionCountsByEmoji).map((key) => reactionCountsByEmoji[key]),
         images,
       },
     });


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
1. reaction 생성
2. reaction 취소
3. 거래 후기 Response에 reactionSummaries를 포함하기

## 어떻게 해결했나요?
1. create reaction handler - cancel 된 Reaction이 존재할 경우 readd, 없을 경우 create
2. cancel reaction handler - canceledAt 을 new Date() 으로 수정
3. include ReactionSummaryResponse in PostWithReactionsResponse

## 참고 자료