### PR TITLE
feat: add comment count in post response, add commentUpdated, Deleted Subscriptions

### DIFF
--- a/apps/api/src/app/comment/comment.resolver.ts
+++ b/apps/api/src/app/comment/comment.resolver.ts
@@ -17,11 +17,16 @@ import { OptionalJwtUserGuard } from '@lib/domains/auth/guards/jwt/optional-jwt-
 import { FindCommentsArgs } from '@lib/domains/comment/application/queries/find-comments/find-comments.args';
 import { FindCommentsQuery } from '@lib/domains/comment/application/queries/find-comments/find-comments.query';
 import { PaginatedCommentsResponse } from '@lib/domains/comment/application/queries/find-comments/paginated-comments.response';
-import { DeleteCommentResult } from '@lib/domains/comment/application/dtos/delete-comment.result';
+import { DeletedCommentResponse } from '@lib/domains/comment/application/commands/delete-comment/deleted-comment.response';
 import { CommentWithAuthorResponse } from '@lib/domains/comment/application/dtos/comment-with-author.response';
 import { GraphqlPubSub } from '@lib/shared/pubsub/graphql-pub-sub';
 import { parseCommentCreatedTriggerName } from '@lib/domains/comment/application/subscriptions/comment-created/parse-comment-created-trigger-name';
 import { CommentCreatedArgs } from '@lib/domains/comment/application/subscriptions/comment-created/comment-created.args';
+import { CommentDeletedArgs } from '@lib/domains/comment/application/subscriptions/comment-deleted/comment-deleted.args';
+import { parseCommentDeletedTriggerName } from '@lib/domains/comment/application/subscriptions/comment-deleted/parse-comment-deleted-trigger-name';
+import { UpdatedCommentResponse } from '@lib/domains/comment/application/commands/update-comment/updated-comment.response';
+import { CommentUpdatedArgs } from '@lib/domains/comment/application/subscriptions/comment-updated/comment-updated.args';
+import { parseCommentUpdatedTriggerName } from '@lib/domains/comment/application/subscriptions/comment-updated/parse-comment-updated-trigger-name';
 import { GqlThrottlerBehindProxyGuard } from '../throttler/gql-throttler-behind-proxy.guard';
 
 @Resolver()
@@ -59,25 +64,37 @@ export class CommentResolver {
   }
 
   @UseGuards(GqlThrottlerBehindProxyGuard, RequiredJwtUserGuard)
-  @Mutation(() => CommentResponse)
+  @Mutation(() => String)
   async updateComment(
     @Args('input') input: UpdateCommentInput,
     @ExtractedUser() user: MyUserResponse,
   ) {
-    return this.commandBus.execute(new UpdateCommentCommand({ input, user }));
+    await this.commandBus.execute(new UpdateCommentCommand({ input, user }));
+    return input.id;
   }
 
   @UseGuards(GqlThrottlerBehindProxyGuard, RequiredJwtUserGuard)
-  @Mutation(() => DeleteCommentResult)
+  @Mutation(() => String)
   async deleteComment(
     @Args('input') input: DeleteCommentInput,
     @ExtractedUser() user: MyUserResponse,
   ) {
-    return this.commandBus.execute(new DeleteCommentCommand({ input, user }));
+    await this.commandBus.execute(new DeleteCommentCommand({ input, user }));
+    return input.id;
   }
 
   @Subscription(() => CommentWithAuthorResponse)
   async commentCreated(@Args() args: CommentCreatedArgs) {
     return GraphqlPubSub.asyncIterator(parseCommentCreatedTriggerName(args.postId));
+  }
+
+  @Subscription(() => UpdatedCommentResponse)
+  async commentUpdated(@Args() args: CommentUpdatedArgs) {
+    return GraphqlPubSub.asyncIterator(parseCommentUpdatedTriggerName(args.postId));
+  }
+
+  @Subscription(() => DeletedCommentResponse)
+  async commentDeleted(@Args() args: CommentDeletedArgs) {
+    return GraphqlPubSub.asyncIterator(parseCommentDeletedTriggerName(args.postId));
   }
 }

--- a/apps/api/src/app/reaction/reaction.resolver.ts
+++ b/apps/api/src/app/reaction/reaction.resolver.ts
@@ -30,8 +30,8 @@ export class ReactionResolver {
     private readonly queryBus: QueryBus,
   ) {}
 
-  @UseGuards(GqlThrottlerBehindProxyGuard)
   @Query(() => [ReactionResponse])
+  @UseGuards(GqlThrottlerBehindProxyGuard)
   async findReactions(@Args() args: FindReactionsArgs) {
     return this.queryBus.execute(new FindReactionsQuery({ args }));
   }

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -183,7 +183,7 @@ input DeleteCommentInput {
   id: ID!
 }
 
-type DeleteCommentResult {
+type DeletedCommentResponse {
   id: ID!
 }
 
@@ -268,7 +268,7 @@ type Mutation {
   createSignedUrl(input: CreateSignedUrlInput!): SignedUrlResponse!
   createUserImage(input: CreateUserImageInput!): String!
   createUserReview(input: CreateUserReviewInput!): String!
-  deleteComment(input: DeleteCommentInput!): DeleteCommentResult!
+  deleteComment(input: DeleteCommentInput!): String!
   deleteOffer(id: ID!): String!
   deleteRole(id: ID!): String!
   deleteUserImage(id: ID!): String!
@@ -276,7 +276,7 @@ type Mutation {
   logout: SocialUserResponse!
   reGenerateTokens: JwtResponse!
   refreshTokens: JwtResponse!
-  updateComment(input: UpdateCommentInput!): CommentResponse!
+  updateComment(input: UpdateCommentInput!): String!
   updateGroup(input: UpdateGroupInput!): String!
   updateOffer(input: UpdateOfferInput!): OfferPreviewResponse!
   updateReportComment(input: UpdateReportCommentInput!): ReportCommentResponse!
@@ -590,6 +590,8 @@ type SocialUserResponse {
 
 type Subscription {
   commentCreated(postId: ID!): CommentWithAuthorResponse!
+  commentDeleted(postId: ID!): DeletedCommentResponse!
+  commentUpdated(postId: ID!): UpdatedCommentResponse!
   reactionCanceled(postId: ID!, type: String!): CanceledReactionResponse!
   reactionCreated(postId: ID!, type: String!): ReactionResponse!
 }
@@ -672,6 +674,12 @@ input UpdateUserInput {
   name: String
   phoneNumber: String
   username: String
+}
+
+type UpdatedCommentResponse {
+  content: String!
+  id: ID!
+  updatedAt: DateTime!
 }
 
 type UserImageResponse {

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -52,6 +52,7 @@ type CommentResponse {
   id: ID!
   parentId: ID
   postId: ID!
+  reactions: [ReactionResponse!]!
   updatedAt: DateTime!
 }
 
@@ -61,6 +62,7 @@ type CommentWithAuthorResponse {
   id: ID!
   parentId: ID
   postId: ID!
+  reactions: [ReactionResponse!]!
   updatedAt: DateTime!
   user: AuthorResponse!
 }

--- a/apps/api/src/schema.gql
+++ b/apps/api/src/schema.gql
@@ -382,6 +382,7 @@ type PaginatedUsersResponse {
 type PostPreviewWithAuthorResponse {
   archivedAt: DateTime
   categoryId: String
+  commentCount: Int
   createdAt: DateTime!
   groupId: String!
   id: ID!
@@ -400,6 +401,7 @@ type PostPreviewWithAuthorResponse {
 type PostPreviewWithUserResponse {
   archivedAt: DateTime
   categoryId: String
+  commentCount: Int
   createdAt: DateTime!
   groupId: String!
   id: ID!
@@ -418,6 +420,7 @@ type PostPreviewWithUserResponse {
 type PostPreviewWithoutUserResponse {
   archivedAt: DateTime
   categoryId: String
+  commentCount: Int
   createdAt: DateTime!
   groupId: String!
   id: ID!
@@ -436,6 +439,7 @@ type PostResponse {
   archivedAt: DateTime
   category: CategoryResponse
   categoryId: String
+  commentCount: Int
   createdAt: DateTime!
   group: GroupProfileResponse!
   groupId: String!

--- a/libs/domains/src/comment/application/commands/create-comment/create-comment.handler.ts
+++ b/libs/domains/src/comment/application/commands/create-comment/create-comment.handler.ts
@@ -56,7 +56,10 @@ export class CreateCommentHandler extends PrismaCommandHandler<
     if (!newComment) throw new ForbiddenException(CommentErrorMessage.COMMENT_CREATION_FAILED);
 
     await GraphqlPubSub.publish(parseCommentCreatedTriggerName(newComment.postId), {
-      commentCreated: newComment,
+      commentCreated: {
+        ...newComment,
+        reactions: [],
+      },
     });
   }
 }

--- a/libs/domains/src/comment/application/commands/delete-comment/delete-comment.handler.ts
+++ b/libs/domains/src/comment/application/commands/delete-comment/delete-comment.handler.ts
@@ -2,25 +2,27 @@ import { CommandHandler, EventPublisher } from '@nestjs/cqrs';
 import { ForbiddenException, Inject, NotFoundException } from '@nestjs/common';
 import { CommentErrorMessage } from '@lib/domains/comment/domain/comment.error.message';
 import { PrismaCommandHandler } from '@lib/shared/cqrs/commands/handlers/prisma-command.handler';
+import { GraphqlPubSub } from '@lib/shared/pubsub/graphql-pub-sub';
 import { DeleteCommentCommand } from './delete-comment.command';
 import { CommentSavePort } from '../../ports/out/comment.save.port';
 import { CommentLoadPort } from '../../ports/out/comment.load.port';
-import { DeleteCommentResult } from '../../dtos/delete-comment.result';
+import { DeletedCommentResponse } from './deleted-comment.response';
+import { parseCommentDeletedTriggerName } from '../../subscriptions/comment-deleted/parse-comment-deleted-trigger-name';
 
 @CommandHandler(DeleteCommentCommand)
 export class DeleteCommentHandler extends PrismaCommandHandler<
   DeleteCommentCommand,
-  DeleteCommentResult
+  DeletedCommentResponse
 > {
   constructor(
     @Inject('CommentLoadPort') private loadPort: CommentLoadPort,
     @Inject('CommentSavePort') private savePort: CommentSavePort,
     private readonly publisher: EventPublisher,
   ) {
-    super(DeleteCommentResult);
+    super(DeletedCommentResponse);
   }
 
-  async execute(command: DeleteCommentCommand): Promise<DeleteCommentResult> {
+  async execute(command: DeleteCommentCommand): Promise<void> {
     const comment = await this.loadPort.findById(command.id);
     if (!comment) throw new NotFoundException(CommentErrorMessage.COMMENT_NOT_FOUND);
     if (!comment.isAuthorized(command.user.id))
@@ -29,8 +31,11 @@ export class DeleteCommentHandler extends PrismaCommandHandler<
       );
 
     await this.savePort.delete(comment);
-    return this.parseResponse({
-      id: comment.id,
+
+    await GraphqlPubSub.publish(parseCommentDeletedTriggerName(comment.postId), {
+      commentDeleted: {
+        id: comment.id,
+      },
     });
   }
 }

--- a/libs/domains/src/comment/application/commands/delete-comment/deleted-comment.response.ts
+++ b/libs/domains/src/comment/application/commands/delete-comment/deleted-comment.response.ts
@@ -1,11 +1,11 @@
 import { Field, ID, ObjectType } from '@nestjs/graphql';
 
 @ObjectType()
-export class DeleteCommentResult {
+export class DeletedCommentResponse {
   @Field(() => ID)
   id: string;
 
-  constructor(partial: Partial<DeleteCommentResult>) {
+  constructor(partial: Partial<DeletedCommentResponse>) {
     Object.assign(this, partial);
   }
 }

--- a/libs/domains/src/comment/application/commands/update-comment/update-comment.handler.ts
+++ b/libs/domains/src/comment/application/commands/update-comment/update-comment.handler.ts
@@ -3,25 +3,27 @@ import { ForbiddenException, Inject, NotFoundException } from '@nestjs/common';
 import { CommentErrorMessage } from '@lib/domains/comment/domain/comment.error.message';
 import { pick } from 'lodash';
 import { PrismaCommandHandler } from '@lib/shared/cqrs/commands/handlers/prisma-command.handler';
+import { GraphqlPubSub } from '@lib/shared/pubsub/graphql-pub-sub';
 import { UpdateCommentCommand } from './update-comment.command';
 import { CommentSavePort } from '../../ports/out/comment.save.port';
 import { CommentLoadPort } from '../../ports/out/comment.load.port';
-import { CommentResponse } from '../../dtos/comment.response';
+import { parseCommentUpdatedTriggerName } from '../../subscriptions/comment-updated/parse-comment-updated-trigger-name';
+import { UpdatedCommentResponse } from './updated-comment.response';
 
 @CommandHandler(UpdateCommentCommand)
 export class UpdateCommentHandler extends PrismaCommandHandler<
   UpdateCommentCommand,
-  CommentResponse
+  UpdatedCommentResponse
 > {
   constructor(
     @Inject('CommentLoadPort') private loadPort: CommentLoadPort,
     @Inject('CommentSavePort') private savePort: CommentSavePort,
     private readonly publisher: EventPublisher,
   ) {
-    super(CommentResponse);
+    super(UpdatedCommentResponse);
   }
 
-  async execute(command: UpdateCommentCommand): Promise<CommentResponse> {
+  async execute(command: UpdateCommentCommand): Promise<void> {
     const comment = await this.loadPort.findById(command.id);
     if (!comment) throw new NotFoundException(CommentErrorMessage.COMMENT_NOT_FOUND);
     if (!comment.isAuthorized(command.user.id))
@@ -29,6 +31,13 @@ export class UpdateCommentHandler extends PrismaCommandHandler<
 
     comment.update(pick(command, ['id', 'content']));
     await this.savePort.save(comment);
-    return this.parseResponse(comment);
+
+    await GraphqlPubSub.publish(parseCommentUpdatedTriggerName(comment.postId), {
+      commentUpdated: {
+        id: comment.id,
+        updatedAt: comment.updatedAt,
+        content: comment.content,
+      },
+    });
   }
 }

--- a/libs/domains/src/comment/application/commands/update-comment/update-comment.handler.ts
+++ b/libs/domains/src/comment/application/commands/update-comment/update-comment.handler.ts
@@ -32,11 +32,14 @@ export class UpdateCommentHandler extends PrismaCommandHandler<
     comment.update(pick(command, ['id', 'content']));
     await this.savePort.save(comment);
 
+    const updatedComment = await this.loadPort.findById(comment.id);
+    if (!updatedComment) throw new ForbiddenException(CommentErrorMessage.COMMENT_UPDATE_FAILED);
+
     await GraphqlPubSub.publish(parseCommentUpdatedTriggerName(comment.postId), {
       commentUpdated: {
-        id: comment.id,
-        updatedAt: comment.updatedAt,
-        content: comment.content,
+        id: updatedComment.id,
+        updatedAt: updatedComment.updatedAt,
+        content: updatedComment.content,
       },
     });
   }

--- a/libs/domains/src/comment/application/commands/update-comment/updated-comment.response.ts
+++ b/libs/domains/src/comment/application/commands/update-comment/updated-comment.response.ts
@@ -1,0 +1,17 @@
+import { Field, ID, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class UpdatedCommentResponse {
+  @Field(() => ID)
+  id: string;
+
+  @Field()
+  updatedAt: Date;
+
+  @Field(() => String)
+  content: string;
+
+  constructor(partial: Partial<UpdatedCommentResponse>) {
+    Object.assign(this, partial);
+  }
+}

--- a/libs/domains/src/comment/application/dtos/comment.response.ts
+++ b/libs/domains/src/comment/application/dtos/comment.response.ts
@@ -1,3 +1,4 @@
+import { ReactionResponse } from '@lib/domains/reaction/application/dtos/reaction.response';
 import { Field, ID, ObjectType } from '@nestjs/graphql';
 
 @ObjectType()
@@ -19,6 +20,9 @@ export class CommentResponse {
 
   @Field(() => String)
   content: string;
+
+  @Field(() => [ReactionResponse])
+  reactions: ReactionResponse[];
 
   constructor(partial: Partial<CommentResponse>) {
     Object.assign(this, partial);

--- a/libs/domains/src/comment/application/queries/find-comment/find-comment.handler.ts
+++ b/libs/domains/src/comment/application/queries/find-comment/find-comment.handler.ts
@@ -15,6 +15,16 @@ export class FindCommentHandler extends PrismaQueryHandler<FindCommentQuery, Com
         id: query.id,
         postId: query.postId,
       },
+      include: {
+        reactions: {
+          where: {
+            canceledAt: null,
+          },
+          include: {
+            emoji: true,
+          },
+        },
+      },
     });
     return this.parseResponse(comment);
   }

--- a/libs/domains/src/comment/application/queries/find-comments/find-comments.handler.ts
+++ b/libs/domains/src/comment/application/queries/find-comments/find-comments.handler.ts
@@ -57,6 +57,14 @@ export class FindCommentsHandler extends PrismaQueryHandler<
             socialAccounts: true,
           },
         },
+        reactions: {
+          where: {
+            canceledAt: null,
+          },
+          include: {
+            emoji: true,
+          },
+        },
       },
     });
 

--- a/libs/domains/src/comment/application/subscriptions/comment-deleted/comment-deleted.args.ts
+++ b/libs/domains/src/comment/application/subscriptions/comment-deleted/comment-deleted.args.ts
@@ -1,0 +1,9 @@
+import { ArgsType, Field, ID } from '@nestjs/graphql';
+import { IsUUID } from 'class-validator';
+
+@ArgsType()
+export class CommentDeletedArgs {
+  @IsUUID()
+  @Field(() => ID)
+  postId: string;
+}

--- a/libs/domains/src/comment/application/subscriptions/comment-deleted/parse-comment-deleted-trigger-name.ts
+++ b/libs/domains/src/comment/application/subscriptions/comment-deleted/parse-comment-deleted-trigger-name.ts
@@ -1,0 +1,1 @@
+export const parseCommentDeletedTriggerName = (postId: string) => `commentDeleted-${postId}`;

--- a/libs/domains/src/comment/application/subscriptions/comment-updated/comment-updated.args.ts
+++ b/libs/domains/src/comment/application/subscriptions/comment-updated/comment-updated.args.ts
@@ -1,0 +1,9 @@
+import { ArgsType, Field, ID } from '@nestjs/graphql';
+import { IsUUID } from 'class-validator';
+
+@ArgsType()
+export class CommentUpdatedArgs {
+  @IsUUID()
+  @Field(() => ID)
+  postId: string;
+}

--- a/libs/domains/src/comment/application/subscriptions/comment-updated/parse-comment-updated-trigger-name.ts
+++ b/libs/domains/src/comment/application/subscriptions/comment-updated/parse-comment-updated-trigger-name.ts
@@ -1,0 +1,1 @@
+export const parseCommentUpdatedTriggerName = (postId: string) => `commentUpdated-${postId}`;

--- a/libs/domains/src/comment/domain/comment.error.message.ts
+++ b/libs/domains/src/comment/domain/comment.error.message.ts
@@ -4,4 +4,5 @@ export enum CommentErrorMessage {
   COMMENT_DELETE_COMMAND_FROM_UNAUTHORIZED_USER = 'Comment delete command from unauthorized user',
   CREATE_COMMENT_REQUEST_FROM_UNAUTHORIZED_USER = 'Create comment request from unauthorized user',
   COMMENT_CREATION_FAILED = 'Comment creation failed',
+  COMMENT_UPDATE_FAILED = 'Comment update failed',
 }

--- a/libs/domains/src/post/application/dtos/post-preview-without-user.response.ts
+++ b/libs/domains/src/post/application/dtos/post-preview-without-user.response.ts
@@ -45,6 +45,9 @@ export class PostPreviewWithoutUserResponse {
   @Field(() => [TagResponse])
   tags: TagResponse[];
 
+  @Field(() => Int, { nullable: true })
+  commentCount: number | null;
+
   constructor(partial: Partial<PostPreviewWithoutUserResponse>) {
     Object.assign(this, partial);
   }

--- a/libs/domains/src/reaction/adapter/out/persistence/reaction.repository.ts
+++ b/libs/domains/src/reaction/adapter/out/persistence/reaction.repository.ts
@@ -30,7 +30,7 @@ export class ReactionRepository
     userId,
   }: {
     emojiId: string;
-    postId?: string | undefined;
+    postId: string;
     commentId?: string | undefined;
     userId: string;
   }) {
@@ -38,7 +38,7 @@ export class ReactionRepository
       where: {
         emojiId,
         postId,
-        commentId,
+        commentId: commentId || null,
         userId,
       },
     });

--- a/libs/domains/src/reaction/application/commands/cancel-reaction/cancel-reaction.command.ts
+++ b/libs/domains/src/reaction/application/commands/cancel-reaction/cancel-reaction.command.ts
@@ -5,7 +5,7 @@ import { CancelReactionInput } from './cancel-reaction.input';
 export class CancelReactionCommand implements ICommand {
   emojiId: string;
 
-  postId?: string;
+  postId: string;
 
   commentId?: string;
 

--- a/libs/domains/src/reaction/application/commands/create-reaction/create-reaction.command.ts
+++ b/libs/domains/src/reaction/application/commands/create-reaction/create-reaction.command.ts
@@ -7,7 +7,7 @@ export class CreateReactionCommand implements ICommand {
 
   emojiId: string;
 
-  postId?: string;
+  postId: string;
 
   commentId?: string;
 

--- a/libs/domains/src/reaction/application/ports/out/reaction.load.port.ts
+++ b/libs/domains/src/reaction/application/ports/out/reaction.load.port.ts
@@ -9,7 +9,7 @@ export interface ReactionLoadPort extends LoadPort<ReactionEntity> {
     userId,
   }: {
     emojiId: string;
-    postId?: string;
+    postId: string;
     commentId?: string;
     userId: string;
   }) => Promise<ReactionEntity | null>;

--- a/libs/domains/src/reaction/application/queries/find-reactions/find-reactions.handler.ts
+++ b/libs/domains/src/reaction/application/queries/find-reactions/find-reactions.handler.ts
@@ -13,7 +13,7 @@ export class FindReactionsHandler extends PrismaQueryHandler<FindReactionsQuery,
     const reactions = await this.prismaService.reaction.findMany({
       where: {
         postId: query.postId,
-        commentId: query.commentId,
+        commentId: query.commentId || null,
         canceledAt: null,
       },
       orderBy: [
@@ -27,6 +27,7 @@ export class FindReactionsHandler extends PrismaQueryHandler<FindReactionsQuery,
         emoji: true,
       },
     });
+
     return this.parseResponses(reactions);
   }
 }

--- a/libs/domains/src/user-review/application/queries/find-user-review-previews/find-user-review-previews.handler.ts
+++ b/libs/domains/src/user-review/application/queries/find-user-review-previews/find-user-review-previews.handler.ts
@@ -64,6 +64,11 @@ export class FindUserReviewPreviewsHandler extends PrismaQueryHandler<
               },
             },
             tags: true,
+            comments: {
+              select: {
+                id: true,
+              },
+            },
           },
         },
         reviewedUser: {
@@ -87,6 +92,18 @@ export class FindUserReviewPreviewsHandler extends PrismaQueryHandler<
       ],
     });
 
-    return paginate<UserReviewPreviewResponse>(this.parseResponses(userReviews), 'id', query.take);
+    return paginate<UserReviewPreviewResponse>(
+      this.parseResponses(
+        userReviews.map((userReview) => ({
+          ...userReview,
+          post: {
+            ...userReview.post,
+            commentCount: userReview.post.comments.length,
+          },
+        })),
+      ),
+      'id',
+      query.take,
+    );
   }
 }

--- a/libs/domains/src/user-review/application/queries/find-user-review/find-user-review.handler.ts
+++ b/libs/domains/src/user-review/application/queries/find-user-review/find-user-review.handler.ts
@@ -44,6 +44,11 @@ export class FindUserReviewHandler extends PrismaQueryHandler<
               },
             },
             tags: true,
+            comments: {
+              select: {
+                id: true,
+              },
+            },
           },
         },
         reviewedUser: {
@@ -82,6 +87,7 @@ export class FindUserReviewHandler extends PrismaQueryHandler<
       post: {
         ...userReview.post,
         images,
+        commentCount: userReview.post.comments.length,
       },
     });
   }


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
1. post를 불러올 때 댓글 갯수 정보 가져오기
2. 댓글 수정, 삭제 구독
3. post, comment 각각에서 reactions을 불러올 때 생기는 부하 문제

## 어떻게 해결했나요?
1. post.comments.length
2. commentUpdated, commentDeleted subscription
3. post, comment에 reactions 를 포함하여 return
