### PR TITLE
feat: handle existing comments in create many comments

### DIFF
--- a/apps/bot/src/commands/bulk-save/bulk-save-comments.slash-command.handler.ts
+++ b/apps/bot/src/commands/bulk-save/bulk-save-comments.slash-command.handler.ts
@@ -24,21 +24,26 @@ export abstract class BulkSaveCommentsSlashCommandHandler {
   protected discordManager: DiscordManager;
 
   async saveThread(threadChannel: ThreadChannel) {
-    const messageCollection = await threadChannel.messages.fetch();
-    const messageWithUsers = await messageCollection.reduce(
-      async (cc, message) => [
-        ...(await cc),
-        {
-          message,
-          user: await this.userClient.fetchMyUser('discord', message.author),
-        },
-      ],
-      Promise.resolve<MessageWithUser[]>([]),
-    );
-    await this.commentClient.createCommentsFromMessageWithUsers(
-      threadChannel,
-      messageWithUsers.splice(0, messageWithUsers.length - 1),
-    );
+    try {
+      const messageCollection = await threadChannel.messages.fetch();
+      const messageWithUsers = await messageCollection.reduce(
+        async (cc, message) => [
+          ...(await cc),
+          {
+            message,
+            user: await this.userClient.fetchMyUser('discord', message.author),
+          },
+        ],
+        Promise.resolve<MessageWithUser[]>([]),
+      );
+      await this.commentClient.createCommentsFromMessageWithUsers(
+        threadChannel,
+        messageWithUsers.splice(0, messageWithUsers.length - 1),
+      );
+    } catch (e) {
+      // NOTE: do nothing
+      // console.log(e);
+    }
   }
 
   async bulkSave(discordGuild: Guild, guildName: string, categoryName: string, limit: number) {

--- a/libs/domains/src/comment/adapter/out/persistence/comment.repository.ts
+++ b/libs/domains/src/comment/adapter/out/persistence/comment.repository.ts
@@ -2,9 +2,14 @@ import _, { pick } from 'lodash';
 import { Injectable } from '@nestjs/common';
 import { PrismaRepository } from '@lib/shared/cqrs/repositories/prisma-repository';
 import { CommentEntity } from '@lib/domains/comment/domain/comment.entity';
+import { CommentLoadPort } from '@lib/domains/comment/application/ports/out/comment.load.port';
+import { CommentSavePort } from '@lib/domains/comment/application/ports/out/comment.save.port';
 
 @Injectable()
-export class CommentRepository extends PrismaRepository<CommentEntity> {
+export class CommentRepository
+  extends PrismaRepository<CommentEntity>
+  implements CommentLoadPort, CommentSavePort
+{
   constructor() {
     super(CommentEntity);
   }


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
1. bulkSave 실행중 개별 set에서 발생한 에러 처리
2. create many comments 에서의 중복 댓글 생성 문제

## 어떻게 해결했나요?
1. saveThread에서의 try, catch
2. existingComments 검사 후 newComments만 저장
