### PR TITLE
feat: filter messages using findNonExistingMessages bulk-save-offers command handler

### DIFF
--- a/apps/bot/src/apps/offer/buy/parsers/buy.parser.ts
+++ b/apps/bot/src/apps/offer/buy/parsers/buy.parser.ts
@@ -21,6 +21,7 @@ export class BuyParser extends OfferParser {
   parseCreateOfferInput(message: Message, group: GroupResponse): CreateOfferInput {
     const match = this.matchFormat(message.content);
     const post = {
+      id: this.parsePostIdFromMessage(message),
       createdAt: message.createdAt,
       updatedAt: message.editedAt || message.createdAt,
       type: OFFER,

--- a/apps/bot/src/apps/offer/sell/parsers/sell.parser.ts
+++ b/apps/bot/src/apps/offer/sell/parsers/sell.parser.ts
@@ -21,6 +21,7 @@ export class SellParser extends OfferParser {
   parseCreateOfferInput(message: Message, group: GroupResponse): CreateOfferInput {
     const match = this.matchFormat(message.content);
     const post = {
+      id: this.parsePostIdFromMessage(message),
       createdAt: message.createdAt,
       updatedAt: message.editedAt || message.createdAt,
       type: OFFER,

--- a/apps/bot/src/apps/offer/swap/parsers/swap.parser.ts
+++ b/apps/bot/src/apps/offer/swap/parsers/swap.parser.ts
@@ -21,6 +21,7 @@ export class SwapParser extends OfferParser {
   parseCreateOfferInput(message: Message, group: GroupResponse): CreateOfferInput {
     const match = this.matchFormat(message.content);
     const post = {
+      id: this.parsePostIdFromMessage(message),
       createdAt: message.createdAt,
       updatedAt: message.editedAt || message.createdAt,
       type: OFFER,

--- a/apps/bot/src/apps/post/clients/post.client.ts
+++ b/apps/bot/src/apps/post/clients/post.client.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { ThreadChannel } from 'discord.js';
+import { Message, ThreadChannel } from 'discord.js';
 import { CheckPostsNotExistQuery } from '@lib/domains/post/application/quries/check-user-posts-not-exist/check-posts-not-exist.query';
 import { ThreadPost } from '@app/bot/shared/interfaces/post-message.interfaces';
 import { UserImageClient } from '../../user-image/clients/user-image.client';
@@ -21,7 +21,7 @@ export class PostClient extends UserImageClient {
   }
 
   async checkPostsNotExistFromThreadChannels(threadChannels: ThreadChannel[]): Promise<string[]> {
-    const postIds = this.postParser.parsePostIds(threadChannels);
+    const postIds = this.postParser.parsePostIdsFromThreadChannels(threadChannels);
     return this.checkPostsNotExist(postIds);
   }
 
@@ -30,6 +30,18 @@ export class PostClient extends UserImageClient {
     const nonExistingPostIds = await this.checkPostsNotExistFromThreadChannels(threadChannels);
     return threadPosts.filter((threadPost) =>
       nonExistingPostIds.includes(this.postParser.parseIdFromChannel(threadPost.threadChannel)),
+    );
+  }
+
+  async checkPostsNotExistFromMessages(messages: Message[]): Promise<string[]> {
+    const postIds = this.postParser.parsePostIdsFromMessages(messages);
+    return this.checkPostsNotExist(postIds);
+  }
+
+  async findNonExistingMessages(messages: Message[]): Promise<Message[]> {
+    const nonExistingPostIds = await this.checkPostsNotExistFromMessages(messages);
+    return messages.filter((message) =>
+      nonExistingPostIds.includes(this.postParser.parsePostIdFromMessage(message)),
     );
   }
 }

--- a/apps/bot/src/apps/post/parsers/post.parser.ts
+++ b/apps/bot/src/apps/post/parsers/post.parser.ts
@@ -1,10 +1,14 @@
 import { GroupParser } from '@app/bot/apps/group/parsers/group.parser';
 import { Injectable } from '@nestjs/common';
-import { ThreadChannel } from 'discord.js';
+import { Message, ThreadChannel } from 'discord.js';
 
 @Injectable()
 export class PostParser extends GroupParser {
-  parsePostIds(threadChannels: ThreadChannel[]): string[] {
+  parsePostIdsFromThreadChannels(threadChannels: ThreadChannel[]): string[] {
     return threadChannels.map((threadChannel) => this.parseIdFromChannel(threadChannel));
+  }
+
+  parsePostIdsFromMessages(messages: Message[]): string[] {
+    return messages.map((message) => this.parsePostIdFromMessage(message));
   }
 }

--- a/apps/bot/src/commands/bulk-save/bulk-save-offers.slash-command.handler.ts
+++ b/apps/bot/src/commands/bulk-save/bulk-save-offers.slash-command.handler.ts
@@ -6,6 +6,7 @@ import { GroupClient } from '@app/bot/apps/group/clients/group.client';
 import { Guild, Message } from 'discord.js';
 import { MarketChannelType } from '@app/bot/shared/types/market-channel.type';
 import { OfferClient } from '@app/bot/apps/offer/clients/offer.client';
+import { PostClient } from '@app/bot/apps/post/clients/post.client';
 
 @Injectable()
 export abstract class BulkSaveOffersSlashCommandHandler {
@@ -17,6 +18,9 @@ export abstract class BulkSaveOffersSlashCommandHandler {
 
   @Inject()
   protected readonly userClient: UserClient;
+
+  @Inject()
+  protected readonly postClient: PostClient;
 
   protected discordManager: DiscordManager;
 
@@ -45,7 +49,8 @@ export abstract class BulkSaveOffersSlashCommandHandler {
     }
     this.discordManager = new DiscordManager(discordGuild);
     const messages = await this.discordManager.fetchMessagesFromChannels(channelIds, limit);
-    await this.bulkSaveMessages(messages, discordGuild);
+    const nonExistingMessages = await this.postClient.findNonExistingMessages(messages);
+    await this.bulkSaveMessages(nonExistingMessages, discordGuild);
   }
 
   async bulkSaveMessages(messages: Message[], discordGuild: Guild) {

--- a/apps/bot/src/config/config.example.yaml
+++ b/apps/bot/src/config/config.example.yaml
@@ -49,7 +49,6 @@ discord:
 namespace:
   discord:
   group:
-  post:
 document:
   title:
   description:

--- a/apps/bot/src/shared/discord/discord.config.service.ts
+++ b/apps/bot/src/shared/discord/discord.config.service.ts
@@ -20,10 +20,6 @@ export class DiscordConfigService {
     return this.configService.get('namespace.group')!;
   }
 
-  getPostNamespace(): string {
-    return this.configService.get('namespace.post')!;
-  }
-
   getDiscordServers(): DiscordServer[] {
     return this.configService.get('discord.servers')!;
   }

--- a/apps/bot/src/shared/parsers/parser.ts
+++ b/apps/bot/src/shared/parsers/parser.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { v4 as uuid4 } from 'uuid';
-import { BaseChannel, Channel, Message, PartialMessage } from 'discord.js';
+import { BaseChannel, Message, PartialMessage } from 'discord.js';
 import { DiscordIdConverter } from '@app/bot/shared/converters/discord-id-converter';
 import { DiscordConfigService } from '../discord/discord.config.service';
 
@@ -22,6 +22,10 @@ export abstract class Parser {
 
   parseIdFromMessage(message: Message | PartialMessage) {
     return this.discordIdConverter.convertIdUsingDiscordNamespace(message.id);
+  }
+
+  parsePostIdFromMessage(message: Message | PartialMessage) {
+    return this.discordIdConverter.convertIdUsingGroupNamespace(message.id);
   }
 
   parseIdFromChannel(channel: BaseChannel) {


### PR DESCRIPTION
## 해결하려는 문제가 무엇인가요?
1. bulk-save-offers 커맨드를 실행할 때, 이미 생성된 데이터와의 중복 생성 문제

## 어떻게 해결했나요?
1. offer의 postId를 parsePostIdFromMessage(message)로 저장
2. findNonExistingMessages 로 filtering
3. 저장
